### PR TITLE
Add model kwargs to image loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Smaller Features + Bug Fixes
 - Add proper __init__.py files (#581)
+- Add possibility to pass model kwargs to image loader models
 
 ## [v0.0.37] - 2023-10-09
 

--- a/llama_hub/file/image/README.md
+++ b/llama_hub/file/image/README.md
@@ -19,6 +19,10 @@ documents = loader.load_data(file=Path('./receipt.png'))
 # If the Image has plain text, use text_type = "plain_text"
 loader = ImageReader(text_type = "plain_text")
 documents = loader.load_data(file=Path('./image.png'))
+
+# Use the model_kwargs to pass options to the parser function
+loader = ImageReader(text_type = "plain_text", model_kwargs=dict(lang="deu+eng"))
+documents = loader.load_data(file=Path('./image.png'))
 ```
 
 This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/jerryjliu/gpt_index/tree/main/gpt_index) and/or subsequently used as a Tool in a [LangChain](https://github.com/hwchase17/langchain) Agent. See [here](https://github.com/emptycrown/llama-hub/tree/main) for examples.

--- a/llama_hub/file/image/base.py
+++ b/llama_hub/file/image/base.py
@@ -6,7 +6,7 @@ A parser for image files.
 
 import re
 from pathlib import Path
-from typing import Dict, List, Optional, cast
+from typing import Dict, List, Optional, cast, Any
 
 from llama_index.readers.base import BaseReader
 from llama_index.readers.schema.base import Document, ImageDocument
@@ -25,6 +25,7 @@ class ImageReader(BaseReader):
         parser_config: Optional[Dict] = None,
         keep_image: bool = False,
         parse_text: bool = True,
+        model_kwargs: Dict[str, Any] = {},
     ):
         """Init parser."""
         self._text_type = text_type
@@ -47,6 +48,7 @@ class ImageReader(BaseReader):
         self._parser_config = parser_config
         self._keep_image = keep_image
         self._parse_text = parse_text
+        self._model_kwargs = model_kwargs
 
     def load_data(
         self, file: Path, extra_info: Optional[Dict] = None
@@ -96,6 +98,7 @@ class ImageReader(BaseReader):
                     num_beams=3,
                     bad_words_ids=[[processor.tokenizer.unk_token_id]],
                     return_dict_in_generate=True,
+                    **self._model_kwargs,
                 )
 
                 sequence = processor.batch_decode(outputs.sequences)[0]
@@ -108,7 +111,7 @@ class ImageReader(BaseReader):
                 import pytesseract
 
                 model = cast(pytesseract, self._parser_config["model"])
-                text_str = model.image_to_string(image)
+                text_str = model.image_to_string(image, **self._model_kwargs)
 
         return [
             ImageDocument(

--- a/tests/file/image/test_image.py
+++ b/tests/file/image/test_image.py
@@ -1,0 +1,55 @@
+
+from base64 import b64decode
+import os
+import sys
+import tempfile
+
+
+BLACK_PIXEL_PNG = b64decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=")
+
+class ImageMock:
+
+    mode ="RGB"
+
+    def open(self, *args, **kwargs):
+        return ImageMock()
+   
+class DummyModel:
+
+    received_kwargs = None
+
+    def generate(self, *args, **kwargs):
+        self.received_kwargs = kwargs
+
+    def image_to_string(self, *args, **kwargs):
+        self.received_kwargs = kwargs
+        return ""
+
+def test_model_kwargs_with_pytesseract():
+
+    from llama_hub.file.image.base import ImageReader
+
+    # Mock subdependencies to just test the kwargs passing
+    pil_mock = type(sys)("PIL")
+    pil_mock.Image = ImageMock
+    sys.modules["PIL"] = pil_mock
+
+    pytesseract_mock = type(sys)("pytesseract")
+    sys.modules["pytesseract"] = pytesseract_mock
+ 
+    dummy_model = DummyModel()
+
+    parser_config = dict(model=dummy_model, processor=None)
+    model_kwargs = dict(foo="2", bar=3)
+
+    loader = ImageReader(parser_config=parser_config, model_kwargs=model_kwargs)
+    
+    with tempfile.TemporaryDirectory() as tmpdir:
+        test_file_path = os.path.join(tmpdir, "test.png")
+        with open(test_file_path, "wb") as f:
+            f.write(BLACK_PIXEL_PNG)
+
+        loader.load_data(test_file_path)
+    
+    assert dummy_model.received_kwargs is not None
+    assert all(dummy_model.received_kwargs[model_key] == model_val for model_key, model_val in model_kwargs.items())

--- a/tests/file/image/test_image.py
+++ b/tests/file/image/test_image.py
@@ -1,21 +1,22 @@
-
 from base64 import b64decode
 import os
 import sys
 import tempfile
 
 
-BLACK_PIXEL_PNG = b64decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=")
+BLACK_PIXEL_PNG = b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+)
+
 
 class ImageMock:
-
-    mode ="RGB"
+    mode = "RGB"
 
     def open(self, *args, **kwargs):
         return ImageMock()
-   
-class DummyModel:
 
+
+class DummyModel:
     received_kwargs = None
 
     def generate(self, *args, **kwargs):
@@ -25,8 +26,8 @@ class DummyModel:
         self.received_kwargs = kwargs
         return ""
 
-def test_model_kwargs_with_pytesseract():
 
+def test_model_kwargs_with_pytesseract():
     from llama_hub.file.image.base import ImageReader
 
     # Mock subdependencies to just test the kwargs passing
@@ -36,20 +37,23 @@ def test_model_kwargs_with_pytesseract():
 
     pytesseract_mock = type(sys)("pytesseract")
     sys.modules["pytesseract"] = pytesseract_mock
- 
+
     dummy_model = DummyModel()
 
     parser_config = dict(model=dummy_model, processor=None)
     model_kwargs = dict(foo="2", bar=3)
 
     loader = ImageReader(parser_config=parser_config, model_kwargs=model_kwargs)
-    
+
     with tempfile.TemporaryDirectory() as tmpdir:
         test_file_path = os.path.join(tmpdir, "test.png")
         with open(test_file_path, "wb") as f:
             f.write(BLACK_PIXEL_PNG)
 
         loader.load_data(test_file_path)
-    
+
     assert dummy_model.received_kwargs is not None
-    assert all(dummy_model.received_kwargs[model_key] == model_val for model_key, model_val in model_kwargs.items())
+    assert all(
+        dummy_model.received_kwargs[model_key] == model_val
+        for model_key, model_val in model_kwargs.items()
+    )


### PR DESCRIPTION
# Description

In order to pass model options to the image loader model I added the possibility to pass a `model_kwargs` dict to the ImageLoader (e.g. to pass the language option to `pytesseract`)

## Type of Change

Please delete options that are not relevant.

- [ ] New Loader/Tool
- [X] Bug fix / Smaller change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have added a library.json file if a new loader/tool was added
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods