### PR TITLE
close library.json file after reading in utils.

### DIFF
--- a/llama_hub/utils.py
+++ b/llama_hub/utils.py
@@ -14,7 +14,9 @@ def import_loader(reader_str: str) -> Type[BaseReader]:
     """Import or download loader."""
 
     # read library json file
-    json_dict = json.load(open(LIBRARY_JSON_PATH, "r"))
+    with open(LIBRARY_JSON_PATH, "r") as json_file:
+        json_dict = json.load(json_file)
+
     dir_name = str(json_dict[reader_str]["id"])
 
     fmt_dir_name = dir_name.replace("/", ".")


### PR DESCRIPTION
# Description

We open file `library.json` in `utils.py`, however, we do not close it and that leads to 
```
ResourceWarning: unclosed file <_io.TextIOWrapper name='venv/lib/python3.10/site-packages/llama_hub/library.json' mode='r' encoding='UTF-8'>
  json_dict = json.load(open(LIBRARY_JSON_PATH, "r"))
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

## Type of Change

- [x] Bug fix / Smaller change

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

Also ran `poetry run pytest tests` to ensure no test fails.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods