### PR TITLE
JSONReader: Encoding fixes UnicodeDecodeError

### DIFF
--- a/llama_hub/file/json/base.py
+++ b/llama_hub/file/json/base.py
@@ -55,6 +55,7 @@ class JSONReader(BaseReader):
         file: Path,
         is_jsonl: Optional[bool] = False,
         extra_info: Optional[Dict] = None,
+        encoding: Optional[str] = "utf-8"
     ) -> List[Document]:
         """Load data from the input file.
 
@@ -62,13 +63,14 @@ class JSONReader(BaseReader):
             file (Path): Path to the input file.
             is_jsonl (Optional[bool]): If True, indicates that the file is in JSONL format. Defaults to False.
             extra_info (Optional[Dict]): Additional information. Default is None.
+            encoding: (Optional[str]): Encoding of file. Default is UTF-8
 
         Returns:
-            List[Document]: List of documents.
+            List[Document]: List of documents. 
         """
         if not isinstance(file, Path):
             file = Path(file)
-        with open(file, "r") as f:
+        with open(file, "r", encoding=encoding) as f:
             data = []
             if is_jsonl:
                 for line in f:


### PR DESCRIPTION
# Description

Provides additional encoding parameter in JSONReader, default is UTF-8.
Fixes "UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 3445: character maps to <undefined>" on Windows 10 x64

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix / Smaller change

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have added a library.json file if a new loader/tool was added
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods