### PR TITLE
Image reader was ignoring metadata. Added metadata to loaded ImageDocument

### DIFF
--- a/llama_hub/file/image/base.py
+++ b/llama_hub/file/image/base.py
@@ -117,5 +117,6 @@ class ImageReader(BaseReader):
             ImageDocument(
                 text=text_str,
                 image=image_str,
+                extra_info = extra_info or {},
             )
         ]


### PR DESCRIPTION
# Description

ImageReader was ignoring metadata. Added support to include metadata while loading images through this loader. No additional dependency. It's a very simple change. I tested it on my use case where I am implementing a RAG Q&A pipeline on images. Thanks!

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix / Smaller change