### PR TITLE
add document_loader and cache

### DIFF
--- a/llama_hub/llama_packs/fusion_retriever/hybrid_fusion/base.py
+++ b/llama_hub/llama_packs/fusion_retriever/hybrid_fusion/base.py
@@ -1,11 +1,10 @@
 """Hybrid Fusion Retriever Pack."""
-
-
+import os
 from typing import Any, Dict, List
 
 from llama_index.indices.vector_store import VectorStoreIndex
 from llama_index.llama_pack.base import BaseLlamaPack
-from llama_index.schema import TextNode
+from llama_index.schema import TextNode, Document
 from llama_index.query_engine import RetrieverQueryEngine
 from llama_index.indices.service_context import ServiceContext
 from llama_index.retrievers import BM25Retriever, QueryFusionRetriever
@@ -19,19 +18,39 @@ class HybridFusionRetrieverPack(BaseLlamaPack):
     """
 
     def __init__(
-        self,
-        nodes: List[TextNode] = None,
-        chunk_size: int = 256,
-        mode: str = "reciprocal_rerank",
-        vector_similarity_top_k: int = 2,
-        bm25_similarity_top_k: int = 2,
-        fusion_similarity_top_k: int = 2,
-        num_queries: int = 4,
-        **kwargs: Any,
+            self,
+            nodes: List[TextNode] = None,
+            chunk_size: int = 256,
+            mode: str = "reciprocal_rerank",
+            vector_similarity_top_k: int = 2,
+            bm25_similarity_top_k: int = 2,
+            fusion_similarity_top_k: int = 2,
+            num_queries: int = 4,
+            documents: List[Document] = None,
+            cache_dir: str = None,
+            **kwargs: Any,
     ) -> None:
         """Init params."""
         service_context = ServiceContext.from_defaults(chunk_size=chunk_size)
-        index = VectorStoreIndex(nodes, service_context=service_context)
+        if cache_dir is not None and os.path.exists(cache_dir):
+            # Load from cache
+            from llama_index import StorageContext, load_index_from_storage
+            # rebuild storage context
+            storage_context = StorageContext.from_defaults(
+                persist_dir=cache_dir)
+            # load index
+            index = load_index_from_storage(storage_context)
+        elif documents is not None:
+            index = VectorStoreIndex.from_documents(
+                documents=documents, service_context=service_context
+            )
+            # Cache the index
+            index.storage_context.persist()
+        else:
+            index = VectorStoreIndex(nodes, service_context=service_context)
+
+        if cache_dir is not None:
+            index.storage_context.persist(persist_dir=cache_dir)
 
         self.vector_retriever = index.as_retriever(
             similarity_top_k=vector_similarity_top_k

--- a/llama_hub/llama_packs/fusion_retriever/hybrid_fusion/base.py
+++ b/llama_hub/llama_packs/fusion_retriever/hybrid_fusion/base.py
@@ -44,12 +44,10 @@ class HybridFusionRetrieverPack(BaseLlamaPack):
             index = VectorStoreIndex.from_documents(
                 documents=documents, service_context=service_context
             )
-            # Cache the index
-            index.storage_context.persist()
         else:
             index = VectorStoreIndex(nodes, service_context=service_context)
 
-        if cache_dir is not None:
+        if cache_dir is not None and not os.path.exists(cache_dir):
             index.storage_context.persist(persist_dir=cache_dir)
 
         self.vector_retriever = index.as_retriever(

--- a/llama_hub/llama_packs/fusion_retriever/hybrid_fusion/base.py
+++ b/llama_hub/llama_packs/fusion_retriever/hybrid_fusion/base.py
@@ -18,26 +18,26 @@ class HybridFusionRetrieverPack(BaseLlamaPack):
     """
 
     def __init__(
-            self,
-            nodes: List[TextNode] = None,
-            chunk_size: int = 256,
-            mode: str = "reciprocal_rerank",
-            vector_similarity_top_k: int = 2,
-            bm25_similarity_top_k: int = 2,
-            fusion_similarity_top_k: int = 2,
-            num_queries: int = 4,
-            documents: List[Document] = None,
-            cache_dir: str = None,
-            **kwargs: Any,
+        self,
+        nodes: List[TextNode] = None,
+        chunk_size: int = 256,
+        mode: str = "reciprocal_rerank",
+        vector_similarity_top_k: int = 2,
+        bm25_similarity_top_k: int = 2,
+        fusion_similarity_top_k: int = 2,
+        num_queries: int = 4,
+        documents: List[Document] = None,
+        cache_dir: str = None,
+        **kwargs: Any,
     ) -> None:
         """Init params."""
         service_context = ServiceContext.from_defaults(chunk_size=chunk_size)
         if cache_dir is not None and os.path.exists(cache_dir):
             # Load from cache
             from llama_index import StorageContext, load_index_from_storage
+
             # rebuild storage context
-            storage_context = StorageContext.from_defaults(
-                persist_dir=cache_dir)
+            storage_context = StorageContext.from_defaults(persist_dir=cache_dir)
             # load index
             index = load_index_from_storage(storage_context)
         elif documents is not None:


### PR DESCRIPTION
# Description

Added support for documents loader, to initialize the VectorStoreIndex from documents instead of only nodes. Also, added an optional cache directory for anyone who wants to speed up the process.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [v] Bug fix / Smaller change

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [v] I've tested the code both as a separated component and end-to-end
- [v] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [v] I have performed a self-review of my own code
- [v] I have commented my code, particularly in hard-to-understand areas
- [v] I have made corresponding changes to the documentation
- [v] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [v] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods