### PR TITLE
fix the issue#475

### DIFF
--- a/llama_hub/file/cjk_pdf/base.py
+++ b/llama_hub/file/cjk_pdf/base.py
@@ -39,8 +39,8 @@ class CJKPDFReader(BaseReader):
         retstr = StringIO()
         # Create a text converter
         codec = "utf-8"
-        laparams = LAParams()
-        device = TextConverter(rsrcmgr, retstr, codec=codec, laparams=laparams)
+
+        device = TextConverter(rsrcmgr, retstr, codec=codec)
         # Create a PDF interpreter
         interpreter = PDFPageInterpreter(rsrcmgr, device)
         # Open the PDF file


### PR DESCRIPTION
# Description

This is the fix to issue #475 . Remove the LAParam to let pdfminer.six use the default layoout to reason the content. Tests show the parsed result for CJK looks good than the one with LAParam(). Meanwhile, it resolved the issue #475 

Fixes # 475

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix / Smaller change

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have added a library.json file if a new loader/tool was added
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods