### PR TITLE
remove extra_files arg from library for datasets; fix readmes

### DIFF
--- a/llama_hub/llama_datasets/braintrust_coda/README.md
+++ b/llama_hub/llama_datasets/braintrust_coda/README.md
@@ -13,24 +13,29 @@ You can download `llamadatasets` directly using `llamaindex-cli`, which comes in
 llamaindex-cli download-llamadataset BraintrustCodaHelpDeskDataset --download-dir ./data
 ```
 
-You can then inspect the files at `./data`.
+You can then inspect the files at `./data`. When you're ready to load the data into
+python, you can use the below snippet of code:
+
+```python
+from llama_index import SimpleDirectoryReader
+from llama_index.llama_dataset import LabelledRagDataset
+
+rag_dataset = LabelledRagDataset.from_json("./data/rag_dataset.json")
+documents = SimpleDirectoryReader(
+    input_dir="./data/source_files"
+).load_data()
+```
 
 ## Code Usage
 
-You can download the dataset to a directory, say `./data`. Then download the
-convenient `RagEvaluatorPack` llamapack to run your own LlamaIndex RAG pipeline
-with the llamadataset.
+You can download the dataset to a directory, say `./data` directly in Python
+as well. From there, you can use the convenient `RagEvaluatorPack` llamapack to
+run your own LlamaIndex RAG pipeline with the `llamadataset``.
 
 ```python
 from llama_index.llama_dataset import download_llama_dataset
 from llama_index.llama_pack import download_llama_pack
 from llama_index import VectorStoreIndex
-
-# download and install dependencies for rag evaluator pack
-RagEvaluatorPack = download_llama_pack(
-  "RagEvaluatorPack", "./rag_evaluator_pack"
-)
-rag_evaluator_pack = RagEvaluatorPack()
 
 # download and install dependencies for benchmark dataset
 rag_dataset, documents = download_llama_dataset(
@@ -39,8 +44,15 @@ rag_dataset, documents = download_llama_dataset(
 
 # build basic RAG system
 index = VectorStoreIndex.from_documents(documents=documents)
+query_engine = VectorStoreIndex.as_query_engine()
 
-# evaluate
-query_engine = VectorStoreIndex.as_query_engine()  # previously defined, not shown here
-rag_evaluate_pack.run(dataset=paul_graham_qa_data, query_engine=query_engine)
+# evaluate using the RagEvaluatorPack
+RagEvaluatorPack = download_llama_pack(
+  "RagEvaluatorPack", "./rag_evaluator_pack"
+)
+rag_evaluator_pack = RagEvaluatorPack(
+    rag_dataset=rag_dataset,
+    query_engine=query_engine
+)
+benchmark_df = await rag_evaluate_pack.arun()
 ```

--- a/llama_hub/llama_datasets/braintrust_coda/llamaindex_baseline.py
+++ b/llama_hub/llama_datasets/braintrust_coda/llamaindex_baseline.py
@@ -8,7 +8,7 @@ from llama_index import VectorStoreIndex
 async def main():
     # DOWNLOAD LLAMADATASET
     rag_dataset, documents = download_llama_dataset(
-      "BraintrustCodaHelpDeskDataset", "./braintrust_codahdd"
+        "BraintrustCodaHelpDeskDataset", "./braintrust_codahdd"
     )
 
     # BUILD BASIC RAG PIPELINE
@@ -16,15 +16,11 @@ async def main():
     query_engine = index.as_query_engine()
 
     # EVALUATE WITH PACK
-    RagEvaluatorPack = download_llama_pack(
-      "RagEvaluatorPack", "./pack_stuff"
-    )
-    rag_evaluator = RagEvaluatorPack(
-        query_engine=query_engine,
-        rag_dataset=rag_dataset
-    )
+    RagEvaluatorPack = download_llama_pack("RagEvaluatorPack", "./pack_stuff")
+    rag_evaluator = RagEvaluatorPack(query_engine=query_engine, rag_dataset=rag_dataset)
     benchmark_df = await rag_evaluator.arun()
     print(benchmark_df)
+
 
 if __name__ == "__main__":
     loop = asyncio.get_event_loop()

--- a/llama_hub/llama_datasets/braintrust_coda/llamaindex_baseline.py
+++ b/llama_hub/llama_datasets/braintrust_coda/llamaindex_baseline.py
@@ -1,0 +1,31 @@
+import asyncio
+
+from llama_index.llama_dataset import download_llama_dataset
+from llama_index.llama_pack import download_llama_pack
+from llama_index import VectorStoreIndex
+
+
+async def main():
+    # DOWNLOAD LLAMADATASET
+    rag_dataset, documents = download_llama_dataset(
+      "BraintrustCodaHelpDeskDataset", "./braintrust_codahdd"
+    )
+
+    # BUILD BASIC RAG PIPELINE
+    index = VectorStoreIndex.from_documents(documents=documents)
+    query_engine = index.as_query_engine()
+
+    # EVALUATE WITH PACK
+    RagEvaluatorPack = download_llama_pack(
+      "RagEvaluatorPack", "./pack_stuff"
+    )
+    rag_evaluator = RagEvaluatorPack(
+        query_engine=query_engine,
+        rag_dataset=rag_dataset
+    )
+    benchmark_df = await rag_evaluator.arun()
+    print(benchmark_df)
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main)

--- a/llama_hub/llama_datasets/library.json
+++ b/llama_hub/llama_datasets/library.json
@@ -2,19 +2,16 @@
   "PaulGrahamEssayDataset": {
     "id": "llama_datasets/paul_graham_essay",
     "author": "andrei-fajardo",
-    "keywords": ["rag"],
-    "extra_files": ["source.txt"]
+    "keywords": ["rag"]
   },
   "BraintrustCodaHelpDeskDataset": {
     "id": "llama_datasets/braintrust_coda",
     "author": "kenny-wong",
-    "keywords": ["rag"],
-    "extra_files": ["section_0.md", "section_1.md", "section_2.md", "section_3.md", "section_4.md", "section_5.md", "section_6.md", "section_7.md", "section_8.md", "section_9.md", "section_10.md", "section_11.md", "section_12.md", "section_13.md", "section_14.md", "section_15.md", "section_16.md", "section_17.md", "section_18.md", "section_19.md", "section_20.md", "section_21.md", "section_22.md", "section_23.md", "section_24.md", "section_25.md", "section_26.md", "section_27.md", "section_28.md", "section_29.md", "section_30.md", "section_31.md", "section_32.md", "section_33.md", "section_34.md", "section_35.md", "section_36.md", "section_37.md", "section_38.md", "section_39.md", "section_40.md", "section_41.md", "section_42.md", "section_43.md", "section_44.md", "section_45.md", "section_46.md", "section_47.md", "section_48.md", "section_49.md"]
+    "keywords": ["rag", "help desk"]
   },
   "PatronusAIFinanceBenchDataset": {
     "id": "llama_datasets/patronus_financebench",
     "author": "anand",
-    "keywords": ["rag"],
-    "extra_files": ["-6927891925076153667.pdf", "-7202804836132812435.pdf", "5420696008997632157.pdf", "-1259278093432956000.pdf", "8255010981931466649.pdf", "3640927171460586089.pdf", "2285064414955059570.pdf", "-952231812766963598.pdf", "7585536068186288071.pdf", "-8614230448635868.pdf", "2373172441154640167.pdf", "5778020429057004799.pdf", "-6705194003955227682.pdf", "-5211952102302999032.pdf", "-1487443078825766914.pdf", "-2391628177033683478.pdf", "1442095295620132897.pdf", "8356595383350674852.pdf", "1492918447230031624.pdf", "-285462274670044281.pdf", "7373122028475438887.pdf", "5236576729232243478.pdf", "6400658416673335614.pdf", "-496066814727482612.pdf", "6473351792252921673.pdf", "2963986444829225983.pdf", "6926845495504563703.pdf", "-5969702240604939055.pdf", "-6546882555099552907.pdf", "-1994176231209798888.pdf", "4523106881982950725.pdf", "-6730121070246638068.pdf"]
+    "keywords": ["rag", "finance"]
   }
 }

--- a/llama_hub/llama_datasets/patronus_financebench/README.md
+++ b/llama_hub/llama_datasets/patronus_financebench/README.md
@@ -16,24 +16,29 @@ You can download `llamadatasets` directly using `llamaindex-cli`, which comes in
 llamaindex-cli download-llamadataset PatronusAIFinanceBenchDataset --download-dir ./data
 ```
 
-You can then inspect the files at `./data`.
+You can then inspect the files at `./data`. When you're ready to load the data into
+python, you can use the below snippet of code:
+
+```python
+from llama_index import SimpleDirectoryReader
+from llama_index.llama_dataset import LabelledRagDataset
+
+rag_dataset = LabelledRagDataset.from_json("./data/rag_dataset.json")
+documents = SimpleDirectoryReader(
+    input_dir="./data/source_files"
+).load_data()
+```
 
 ## Code Usage
 
-You can download the dataset to a directory, say `./data`. Then download the
-convenient `RagEvaluatorPack` llamapack to run your own LlamaIndex RAG pipeline
-with the llamadataset.
+You can download the dataset to a directory, say `./data` directly in Python
+as well. From there, you can use the convenient `RagEvaluatorPack` llamapack to
+run your own LlamaIndex RAG pipeline with the `llamadataset``.
 
 ```python
 from llama_index.llama_dataset import download_llama_dataset
 from llama_index.llama_pack import download_llama_pack
 from llama_index import VectorStoreIndex
-
-# download and install dependencies for rag evaluator pack
-RagEvaluatorPack = download_llama_pack(
-  "RagEvaluatorPack", "./rag_evaluator_pack"
-)
-rag_evaluator_pack = RagEvaluatorPack()
 
 # download and install dependencies for benchmark dataset
 rag_dataset, documents = download_llama_dataset(
@@ -42,8 +47,15 @@ rag_dataset, documents = download_llama_dataset(
 
 # build basic RAG system
 index = VectorStoreIndex.from_documents(documents=documents)
+query_engine = VectorStoreIndex.as_query_engine()
 
-# evaluate
-query_engine = VectorStoreIndex.as_query_engine()  # previously defined, not shown here
-rag_evaluate_pack.run(dataset=paul_graham_qa_data, query_engine=query_engine)
+# evaluate using the RagEvaluatorPack
+RagEvaluatorPack = download_llama_pack(
+  "RagEvaluatorPack", "./rag_evaluator_pack"
+)
+rag_evaluator_pack = RagEvaluatorPack(
+    rag_dataset=rag_dataset,
+    query_engine=query_engine
+)
+benchmark_df = await rag_evaluate_pack.arun()
 ```

--- a/llama_hub/llama_datasets/patronus_financebench/llamaindex_baseline.py
+++ b/llama_hub/llama_datasets/patronus_financebench/llamaindex_baseline.py
@@ -1,0 +1,31 @@
+import asyncio
+
+from llama_index.llama_dataset import download_llama_dataset
+from llama_index.llama_pack import download_llama_pack
+from llama_index import VectorStoreIndex
+
+
+async def main():
+    # DOWNLOAD LLAMADATASET
+    rag_dataset, documents = download_llama_dataset(
+      "PatronusAIFinanceBenchDataset", "./patronus_financebench"
+    )
+
+    # BUILD BASIC RAG PIPELINE
+    index = VectorStoreIndex.from_documents(documents=documents)
+    query_engine = index.as_query_engine()
+
+    # EVALUATE WITH PACK
+    RagEvaluatorPack = download_llama_pack(
+      "RagEvaluatorPack", "./pack_stuff"
+    )
+    rag_evaluator = RagEvaluatorPack(
+        query_engine=query_engine,
+        rag_dataset=rag_dataset
+    )
+    benchmark_df = await rag_evaluator.arun()
+    print(benchmark_df)
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main)

--- a/llama_hub/llama_datasets/patronus_financebench/llamaindex_baseline.py
+++ b/llama_hub/llama_datasets/patronus_financebench/llamaindex_baseline.py
@@ -8,7 +8,7 @@ from llama_index import VectorStoreIndex
 async def main():
     # DOWNLOAD LLAMADATASET
     rag_dataset, documents = download_llama_dataset(
-      "PatronusAIFinanceBenchDataset", "./patronus_financebench"
+        "PatronusAIFinanceBenchDataset", "./patronus_financebench"
     )
 
     # BUILD BASIC RAG PIPELINE
@@ -16,15 +16,11 @@ async def main():
     query_engine = index.as_query_engine()
 
     # EVALUATE WITH PACK
-    RagEvaluatorPack = download_llama_pack(
-      "RagEvaluatorPack", "./pack_stuff"
-    )
-    rag_evaluator = RagEvaluatorPack(
-        query_engine=query_engine,
-        rag_dataset=rag_dataset
-    )
+    RagEvaluatorPack = download_llama_pack("RagEvaluatorPack", "./pack_stuff")
+    rag_evaluator = RagEvaluatorPack(query_engine=query_engine, rag_dataset=rag_dataset)
     benchmark_df = await rag_evaluator.arun()
     print(benchmark_df)
+
 
 if __name__ == "__main__":
     loop = asyncio.get_event_loop()

--- a/llama_hub/llama_datasets/paul_graham_essay/README.md
+++ b/llama_hub/llama_datasets/paul_graham_essay/README.md
@@ -8,24 +8,29 @@ You can download `llamadatasets` directly using `llamaindex-cli`, which comes in
 llamaindex-cli download-llamadataset PaulGrahamEssayDataset --download-dir ./data
 ```
 
-You can then inspect the files at `./data`.
+You can then inspect the files at `./data`. When you're ready to load the data into
+python, you can use the below snippet of code:
+
+```python
+from llama_index import SimpleDirectoryReader
+from llama_index.llama_dataset import LabelledRagDataset
+
+rag_dataset = LabelledRagDataset.from_json("./data/rag_dataset.json")
+documents = SimpleDirectoryReader(
+    input_dir="./data/source_files"
+).load_data()
+```
 
 ## Code Usage
 
-You can download the dataset to a directory, say `./data`. Then download the
-convenient `RagEvaluatorPack` llamapack to run your own LlamaIndex RAG pipeline
-with the llamadataset.
+You can download the dataset to a directory, say `./data` directly in Python
+as well. From there, you can use the convenient `RagEvaluatorPack` llamapack to
+run your own LlamaIndex RAG pipeline with the `llamadataset``.
 
 ```python
 from llama_index.llama_dataset import download_llama_dataset
 from llama_index.llama_pack import download_llama_pack
 from llama_index import VectorStoreIndex
-
-# download and install dependencies for rag evaluator pack
-RagEvaluatorPack = download_llama_pack(
-  "RagEvaluatorPack", "./rag_evaluator_pack"
-)
-rag_evaluator_pack = RagEvaluatorPack()
 
 # download and install dependencies for benchmark dataset
 rag_dataset, documents = download_llama_dataset(
@@ -34,9 +39,15 @@ rag_dataset, documents = download_llama_dataset(
 
 # build basic RAG system
 index = VectorStoreIndex.from_documents(documents=documents)
+query_engine = VectorStoreIndex.as_query_engine()
 
-# evaluate
-query_engine = VectorStoreIndex.as_query_engine()  # previously defined, not shown here
-rag_evaluate_pack.run(dataset=paul_graham_qa_data, query_engine=query_engine)
+# evaluate using the RagEvaluatorPack
+RagEvaluatorPack = download_llama_pack(
+  "RagEvaluatorPack", "./rag_evaluator_pack"
+)
+rag_evaluator_pack = RagEvaluatorPack(
+    rag_dataset=rag_dataset,
+    query_engine=query_engine
+)
+benchmark_df = await rag_evaluate_pack.arun()
 ```
-

--- a/llama_hub/llama_datasets/paul_graham_essay/llamaindex_baseline.py
+++ b/llama_hub/llama_datasets/paul_graham_essay/llamaindex_baseline.py
@@ -8,7 +8,7 @@ from llama_index import VectorStoreIndex
 async def main():
     # DOWNLOAD LLAMADATASET
     rag_dataset, documents = download_llama_dataset(
-      "PaulGrahamEssayDataset", "./paul_graham"
+        "PaulGrahamEssayDataset", "./paul_graham"
     )
 
     # BUILD BASIC RAG PIPELINE
@@ -16,15 +16,11 @@ async def main():
     query_engine = index.as_query_engine()
 
     # EVALUATE WITH PACK
-    RagEvaluatorPack = download_llama_pack(
-      "RagEvaluatorPack", "./pack_stuff"
-    )
-    rag_evaluator = RagEvaluatorPack(
-        query_engine=query_engine,
-        rag_dataset=rag_dataset
-    )
+    RagEvaluatorPack = download_llama_pack("RagEvaluatorPack", "./pack_stuff")
+    rag_evaluator = RagEvaluatorPack(query_engine=query_engine, rag_dataset=rag_dataset)
     benchmark_df = await rag_evaluator.arun()
     print(benchmark_df)
+
 
 if __name__ == "__main__":
     loop = asyncio.get_event_loop()

--- a/llama_hub/llama_datasets/paul_graham_essay/llamaindex_baseline.py
+++ b/llama_hub/llama_datasets/paul_graham_essay/llamaindex_baseline.py
@@ -1,0 +1,31 @@
+import asyncio
+
+from llama_index.llama_dataset import download_llama_dataset
+from llama_index.llama_pack import download_llama_pack
+from llama_index import VectorStoreIndex
+
+
+async def main():
+    # DOWNLOAD LLAMADATASET
+    rag_dataset, documents = download_llama_dataset(
+      "PaulGrahamEssayDataset", "./paul_graham"
+    )
+
+    # BUILD BASIC RAG PIPELINE
+    index = VectorStoreIndex.from_documents(documents=documents)
+    query_engine = index.as_query_engine()
+
+    # EVALUATE WITH PACK
+    RagEvaluatorPack = download_llama_pack(
+      "RagEvaluatorPack", "./pack_stuff"
+    )
+    rag_evaluator = RagEvaluatorPack(
+        query_engine=query_engine,
+        rag_dataset=rag_dataset
+    )
+    benchmark_df = await rag_evaluator.arun()
+    print(benchmark_df)
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main)


### PR DESCRIPTION
# Description

- removes `extra_files` from `library.json` for `llama_datasets`
     - the new download tool in framework looks for the source files in a directory called `source_files` so we don't need to list these out any more
- fix readme inconsistencies

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Clean up of datasets metadata artifacts

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have added a library.json file if a new loader/tool was added
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods