### PR TITLE
use alias

### DIFF
--- a/llama_hub/llama_packs/llama_dataset_metadata/base.py
+++ b/llama_hub/llama_packs/llama_dataset_metadata/base.py
@@ -242,7 +242,7 @@ class LlamaDatasetMetadataPack(BaseLlamaPack):
 
         # save card.json
         with open("card.json", "w") as f:
-            json.dump(card_obj.dict(), f)
+            json.dump(card_obj.dict(by_alias=True), f)
 
         # save README.md
         with open("README.md", "w") as f:


### PR DESCRIPTION
# Description

- LlamaDatasetMetadataPack needs to use by_alias=True when invoking json method on Pydantic DatasetCard class in order to get camel case output

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix / Smaller change

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

