### PR TITLE
Correct dataset authors' github usernames

### DIFF
--- a/llama_hub/llama_datasets/library.json
+++ b/llama_hub/llama_datasets/library.json
@@ -11,7 +11,7 @@
   },
   "PatronusAIFinanceBenchDataset": {
     "id": "llama_datasets/patronus_financebench",
-    "author": "anand",
+    "author": "anandnk24",
     "keywords": ["rag", "finance"]
   },
   "BlockchainSolanaDataset": {

--- a/llama_hub/llama_datasets/library.json
+++ b/llama_hub/llama_datasets/library.json
@@ -6,7 +6,7 @@
   },
   "BraintrustCodaHelpDeskDataset": {
     "id": "llama_datasets/braintrust_coda",
-    "author": "kenny-wong",
+    "author": "dashk",
     "keywords": ["rag", "help desk"]
   },
   "PatronusAIFinanceBenchDataset": {


### PR DESCRIPTION
# Description

 - corrects authors for Braintrust-CodaHDD and PatronusAI datasets to use their correct and respective authors' github usernames.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix / Smaller change
