### PR TITLE
Update AzStorageBlobReader

### DIFF
--- a/llama_hub/azstorage_blob/README.md
+++ b/llama_hub/azstorage_blob/README.md
@@ -2,20 +2,44 @@
 
 This loader parses any file stored as an Azure Storage blob or the entire container (with an optional prefix / attribute filter) if no particular file is specified. When initializing `AzStorageBlobReader`, you may pass in your account url with a SAS token or crdentials to authenticate.
 
-All files are temporarily downloaded locally and subsequently parsed with `SimpleDirectoryReader`. Hence, you may also specify a custom `file_extractor`, relying on any of the loaders in this library (or your own)!
+All files are temporarily downloaded locally and subsequently parsed with `SimpleDirectoryReader`. Hence, you may also specify a custom `file_extractor`, relying on any of the loaders in this library (or your own)! If you need a clue on finding the file extractor object because you'd like to use your own file extractor, follow this sample.
+
+```python
+import llama_index
+
+file_extractor = llama_index.readers.file.base.DEFAULT_FILE_READER_CLS
+
+# Make sure to use an instantiation of a class
+file_extractor.update({
+    ".pdf": SimplePDFReader()
+    })
+```
 
 ## Usage
 
 To use this loader, you need to pass in the name of your Azure Storage Container. After that, if you want to just parse a single file, pass in its blob name. Note that if the file is nested in a subdirectory, the blob name should contain the path such as `subdirectory/input.txt`. This loader is a thin wrapper over the [Azure Blob Storage Client for Python](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-python?tabs=managed-identity%2Croles-azure-portal%2Csign-in-azure-cli), see [ContainerClient](https://learn.microsoft.com/en-us/python/api/azure-storage-blob/azure.storage.blob.containerclient?view=azure-python) for detailed parameter usage options. 
 
 
-### Using a Storage Accout SAS URL
+### Using a Storage Account SAS URL
 ```python
 from llama_index import download_loader
 
 AzStorageBlobReader = download_loader("AzStorageBlobReader")
 
 loader = AzStorageBlobReader(container='scrabble-dictionary', blob='dictionary.txt', account_url='<SAS_URL>')
+
+documents = loader.load_data()
+```
+
+### Using a Storage Account with connection string
+The sample below will download all files in a container, by only specifying the storage account's connection string and the container name.
+
+```python
+from llama_index import download_loader
+
+AzStorageBlobReader = download_loader("AzStorageBlobReader")
+
+loader = AzStorageBlobReader(container_name='<CONTAINER_NAME>', connection_string='<STORAGE_ACCOUNT_CONNECTION_STRING>')
 
 documents = loader.load_data()
 ```

--- a/llama_hub/azstorage_blob/base.py
+++ b/llama_hub/azstorage_blob/base.py
@@ -33,7 +33,9 @@ class AzStorageBlobReader(BaseReader):
             'legalhold'.
         file_extractor (Optional[Dict[str, Union[str, BaseReader]]]): A mapping of file
             extension to a BaseReader class that specifies how to convert that file
-            to text. See `SimpleDirectoryReader` for more details.
+            to text. See `SimpleDirectoryReader` for more details, or call this path ```llama_index.readers.file.base.DEFAULT_FILE_READER_CLS```.
+        connection_string (str): A connection string which can be found under a storage account's "Access keys" security tab. This parameter
+        can be used in place of both the account URL and credential. 
         account_url (str): URI to the storage account, may include SAS token.
         credential (Union[str, Dict[str, str], AzureNamedKeyCredential, AzureSasCredential, TokenCredential, None] = None):
             The credentials with which to authenticate. This is optional if the account URL already has a SAS token.
@@ -43,11 +45,13 @@ class AzStorageBlobReader(BaseReader):
         self,
         *args: Any,
         container_name: str,
+        prefix: str = "",
         blob: Optional[str] = None,
         name_starts_with: Optional[str] = None,
         include: Optional[Any] = None,
         file_extractor: Optional[Dict[str, Union[str, BaseReader]]] = None,
-        account_url: str,
+        connection_string: Optional[str] = None,
+        account_url: Optional[str] = None,
         credential: Optional[Any] = None,
         **kwargs: Any,
     ) -> None:
@@ -55,50 +59,55 @@ class AzStorageBlobReader(BaseReader):
         super().__init__(*args, **kwargs)
 
         self.container_name = container_name
+        self.prefix = prefix
+        self.connection_string = connection_string
         self.blob = blob
         self.name_starts_with = name_starts_with
         self.include = include
-
         self.file_extractor = file_extractor
-
         self.account_url = account_url
         self.credential = credential
+        # Not in use. As part of the TODO below. Is part of the kwargs.
+        # self.preloaded_data_path = kwargs.get('preloaded_data_path', None)
 
     def load_data(self) -> List[Document]:
         """Load file(s) from Azure Storage Blob"""
-        # from azure.core.credentials import AzureNamedKeyCredential, AzureSasCredential, TokenCredential
-        # from azure.storage.blob import BlobServiceClient, BlobClient, ContainerClient
         from azure.storage.blob import ContainerClient
 
-        container_client = ContainerClient(
+        if self.connection_string:
+            container_client = ContainerClient.from_connection_string(
+            connection_string=self.connection_string, container_name=self.container_name
+            )
+        else:
+            container_client = ContainerClient(
             self.account_url, self.container_name, credential=self.credential
-        )
+            )
         total_download_start_time = time.time()
 
         with tempfile.TemporaryDirectory() as temp_dir:
             if self.blob:
-                extension = Path(self.blob).suffix
+                stream = container_client.download_blob(self.blob)
                 download_file_path = (
-                    f"{temp_dir}/{next(tempfile._get_candidate_names())}{extension}"
-                )
+                        f"{temp_dir}/{stream.name}"
+                    )
                 logger.info(f"Start download of {self.blob}")
                 start_time = time.time()
-                stream = container_client.download_blob(self.blob)
                 with open(file=download_file_path, mode="wb") as download_file:
                     stream.readinto(download_file)
                 end_time = time.time()
                 logger.info(
                     f"{self.blob} downloaded in {end_time - start_time} seconds."
                 )
+            # TODO: Implement an "elif" for if a pickled dictionary of the Document objects are already stored, to load that in and read into the temp directory.
+            # Needed because the loading of a container can take some time, and if everything is already pickled into local environment, loading it from there will be much faster.
             else:
                 logger.info("Listing blobs")
                 blobs_list = container_client.list_blobs(
                     self.name_starts_with, self.include
                 )
                 for obj in blobs_list:
-                    extension = Path(obj.name).suffix
                     download_file_path = (
-                        f"{temp_dir}/{next(tempfile._get_candidate_names())}{extension}"
+                        f"{temp_dir}/{obj.name}"
                     )
                     logger.info(f"Start download of {obj.name}")
                     start_time = time.time()

--- a/llama_hub/azstorage_blob/base.py
+++ b/llama_hub/azstorage_blob/base.py
@@ -7,7 +7,6 @@ import logging
 import math
 import tempfile
 import time
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from llama_index import download_loader
@@ -35,7 +34,7 @@ class AzStorageBlobReader(BaseReader):
             extension to a BaseReader class that specifies how to convert that file
             to text. See `SimpleDirectoryReader` for more details, or call this path ```llama_index.readers.file.base.DEFAULT_FILE_READER_CLS```.
         connection_string (str): A connection string which can be found under a storage account's "Access keys" security tab. This parameter
-        can be used in place of both the account URL and credential. 
+        can be used in place of both the account URL and credential.
         account_url (str): URI to the storage account, may include SAS token.
         credential (Union[str, Dict[str, str], AzureNamedKeyCredential, AzureSasCredential, TokenCredential, None] = None):
             The credentials with which to authenticate. This is optional if the account URL already has a SAS token.
@@ -76,20 +75,19 @@ class AzStorageBlobReader(BaseReader):
 
         if self.connection_string:
             container_client = ContainerClient.from_connection_string(
-            connection_string=self.connection_string, container_name=self.container_name
+                connection_string=self.connection_string,
+                container_name=self.container_name,
             )
         else:
             container_client = ContainerClient(
-            self.account_url, self.container_name, credential=self.credential
+                self.account_url, self.container_name, credential=self.credential
             )
         total_download_start_time = time.time()
 
         with tempfile.TemporaryDirectory() as temp_dir:
             if self.blob:
                 stream = container_client.download_blob(self.blob)
-                download_file_path = (
-                        f"{temp_dir}/{stream.name}"
-                    )
+                download_file_path = f"{temp_dir}/{stream.name}"
                 logger.info(f"Start download of {self.blob}")
                 start_time = time.time()
                 with open(file=download_file_path, mode="wb") as download_file:
@@ -106,9 +104,7 @@ class AzStorageBlobReader(BaseReader):
                     self.name_starts_with, self.include
                 )
                 for obj in blobs_list:
-                    download_file_path = (
-                        f"{temp_dir}/{obj.name}"
-                    )
+                    download_file_path = f"{temp_dir}/{obj.name}"
                     logger.info(f"Start download of {obj.name}")
                     start_time = time.time()
                     stream = container_client.download_blob(obj)

--- a/llama_hub/library.json
+++ b/llama_hub/library.json
@@ -41,7 +41,10 @@
   },
   "AzStorageBlobReader": {
     "id": "azstorage_blob",
-    "author": "rivms",
+    "author": [
+      "rivms", 
+      "JAlexMcGraw"
+    ],
     "keywords": [
       "azure storage",
       "blob",


### PR DESCRIPTION
# Description

Added functionality to allow user to connect to blob storage with a connection string, instead of credentials and account URL. The credentials and URL functionality still exists. The motivation behind this was on a current work project, using the credentials and account URL did not function. Permissions weren't set right, but using the connection string, I could connect and I had one less parameter to specify.

Changed the temporary file names from random names to the names that are assigned in the container originally. The rationale is that sometimes the original names are needed later on, such as my case that the names were used to create metadata, which could not be done with random names. 

Updated README to reflect this new functionality, and added a tip on how to update file_extractor file to specify a specific different document reader, if needed. Updated library to reflect myself as a contributor/author to this module.


Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix / Smaller change
- [ ] This change requires a documentation update

# How Has This Been Tested?


Created an AzStorageBlobReader instance using only the container name and connection string for the storage account, and was able to load data using the .load_data() method.

To test yourself, instead of specifying a container name, credentials, and account URL, can specify just the container name and connection string. Then, run the load_data() method on the class instantiation.

- [ ] Added new notebook (that tests end-to-end) (Tested this locally and it worked, but did not upload. Would you like me to upload?)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have added a library.json file if a new loader/tool was added
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes (did not test)