### PR TITLE
added kg-rag dataset

### DIFF
--- a/llama_hub/llama_datasets/docugami_kg_rag/sec_10_q/README.md
+++ b/llama_hub/llama_datasets/docugami_kg_rag/sec_10_q/README.md
@@ -5,7 +5,7 @@
 You can download `llamadatasets` directly using `llamaindex-cli`, which comes installed with the `llama-index` python package:
 
 ```bash
-llamaindex-cli download-llamadataset DocugamiKGRAGSEC10Q --download-dir ./data
+llamaindex-cli download-llamadataset DocugamiKgRagSec10Q --download-dir ./data
 ```
 
 You can then inspect the files at `./data`. When you're ready to load the data into
@@ -34,7 +34,7 @@ from llama_index import VectorStoreIndex
 
 # download and install dependencies for benchmark dataset
 rag_dataset, documents = download_llama_dataset(
-  "DocugamiKGRAGSEC10Q ", "./data"
+  "DocugamiKgRagSec10Q ", "./data"
 )
 
 # build basic RAG system

--- a/llama_hub/llama_datasets/docugami_kg_rag/sec_10_q/README.md
+++ b/llama_hub/llama_datasets/docugami_kg_rag/sec_10_q/README.md
@@ -5,7 +5,7 @@
 You can download `llamadatasets` directly using `llamaindex-cli`, which comes installed with the `llama-index` python package:
 
 ```bash
-llamaindex-cli download-llamadataset DocugamiKG-RAG-SEC10-Q --download-dir ./data
+llamaindex-cli download-llamadataset DocugamiKGRAGSEC10Q --download-dir ./data
 ```
 
 You can then inspect the files at `./data`. When you're ready to load the data into
@@ -34,7 +34,7 @@ from llama_index import VectorStoreIndex
 
 # download and install dependencies for benchmark dataset
 rag_dataset, documents = download_llama_dataset(
-  "DocugamiKG-RAG-SEC10-Q ", "./data"
+  "DocugamiKGRAGSEC10Q ", "./data"
 )
 
 # build basic RAG system

--- a/llama_hub/llama_datasets/docugami_kg_rag/sec_10_q/README.md
+++ b/llama_hub/llama_datasets/docugami_kg_rag/sec_10_q/README.md
@@ -1,0 +1,64 @@
+# Docugami KG-RAG - Sec 10-Q
+
+## CLI Usage
+
+You can download `llamadatasets` directly using `llamaindex-cli`, which comes installed with the `llama-index` python package:
+
+```bash
+llamaindex-cli download-llamadataset DocugamiKG-RAG-SEC10-Q --download-dir ./data
+```
+
+You can then inspect the files at `./data`. When you're ready to load the data into
+python, you can use the below snippet of code:
+
+```python
+from llama_index import SimpleDirectoryReader
+from llama_index.llama_dataset import LabelledRagDataset
+
+rag_dataset = LabelledRagDataset.from_json("./data/rag_dataset.json")
+documents = SimpleDirectoryReader(
+    input_dir="./data/source_files"
+).load_data()
+```
+
+## Code Usage
+
+You can download the dataset to a directory, say `./data` directly in Python
+as well. From there, you can use the convenient `RagEvaluatorPack` llamapack to
+run your own LlamaIndex RAG pipeline with the `llamadataset`.
+
+```python
+from llama_index.llama_dataset import download_llama_dataset
+from llama_index.llama_pack import download_llama_pack
+from llama_index import VectorStoreIndex
+
+# download and install dependencies for benchmark dataset
+rag_dataset, documents = download_llama_dataset(
+  "DocugamiKG-RAG-SEC10-Q ", "./data"
+)
+
+# build basic RAG system
+index = VectorStoreIndex.from_documents(documents=documents)
+query_engine = index.as_query_engine()
+
+# evaluate using the RagEvaluatorPack
+RagEvaluatorPack = download_llama_pack(
+  "RagEvaluatorPack", "./rag_evaluator_pack"
+)
+rag_evaluator_pack = RagEvaluatorPack(
+    rag_dataset=rag_dataset,
+    query_engine=query_engine
+)
+
+############################################################################
+# NOTE: If have a lower tier subscription for OpenAI API like Usage Tier 1 #
+# then you'll need to use different batch_size and sleep_time_in_seconds.  #
+# For Usage Tier 1, settings that seemed to work well were batch_size=5,   #
+# and sleep_time_in_seconds=15 (as of December 2023.)                      #
+############################################################################
+
+benchmark_df = await rag_evaluator_pack.arun(
+    batch_size=20,  # batches the number of openai api calls to make
+    sleep_time_in_seconds=1,  # seconds to sleep before making an api call
+)
+```

--- a/llama_hub/llama_datasets/docugami_kg_rag/sec_10_q/card.json
+++ b/llama_hub/llama_datasets/docugami_kg_rag/sec_10_q/card.json
@@ -1,0 +1,26 @@
+{
+    "name": "Docugami KG-RAG - SEC 10-Q",
+    "description": "A labelled RAG dataset with SEC 10-Q documents for major tech companies including queries across multiple docs and chunks, with reference answers. See https://github.com/docugami/KG-RAG-datasets for details.",
+    "numberObservations": 195,
+    "containsExamplesByHumans": true,
+    "containsExamplesByAi": false,
+    "sourceUrls": [],
+    "baselines": [
+        {
+            "name": "llamaindex",
+            "config": {
+                "chunkSize": 1024,
+                "llm": "gpt-3.5-turbo",
+                "similarityTopK": 2,
+                "embedModel": "text-embedding-ada-002"
+            },
+            "metrics": {
+                "contextSimilarity": null,
+                "correctness": 2.703,
+                "faithfulness": 0.897,
+                "relevancy": 0.826
+            },
+            "codeUrl": ""
+        }
+    ]
+}

--- a/llama_hub/llama_datasets/docugami_kg_rag/sec_10_q/llamaindex_baseline.py
+++ b/llama_hub/llama_datasets/docugami_kg_rag/sec_10_q/llamaindex_baseline.py
@@ -9,7 +9,7 @@ from llama_index.llms import OpenAI
 async def main():
     # DOWNLOAD LLAMADATASET
     rag_dataset, documents = download_llama_dataset(
-        "DocugamiKG-RAG-SEC10-Q", "./docugami_kg_rag_sec_10_q"
+        "DocugamiKGRAGSEC10Q", "./docugami_kg_rag_sec_10_q"
     )
 
     # BUILD BASIC RAG PIPELINE

--- a/llama_hub/llama_datasets/docugami_kg_rag/sec_10_q/llamaindex_baseline.py
+++ b/llama_hub/llama_datasets/docugami_kg_rag/sec_10_q/llamaindex_baseline.py
@@ -1,0 +1,41 @@
+import asyncio
+
+from llama_index.llama_dataset import download_llama_dataset
+from llama_index.llama_pack import download_llama_pack
+from llama_index import VectorStoreIndex
+from llama_index.llms import OpenAI
+
+
+async def main():
+    # DOWNLOAD LLAMADATASET
+    rag_dataset, documents = download_llama_dataset(
+        "DocugamiKG-RAG-SEC10-Q", "./docugami_kg_rag_sec_10_q"
+    )
+
+    # BUILD BASIC RAG PIPELINE
+    index = VectorStoreIndex.from_documents(documents=documents)
+    query_engine = index.as_query_engine()
+
+    # EVALUATE WITH PACK
+    RagEvaluatorPack = download_llama_pack("RagEvaluatorPack", "./pack_stuff")
+    judge_llm = OpenAI(model="gpt-3.5-turbo")
+    rag_evaluator = RagEvaluatorPack(
+        query_engine=query_engine, rag_dataset=rag_dataset, judge_llm=judge_llm
+    )
+
+    ############################################################################
+    # NOTE: If have a lower tier subscription for OpenAI API like Usage Tier 1 #
+    # then you'll need to use different batch_size and sleep_time_in_seconds.  #
+    # For Usage Tier 1, settings that seemed to work well were batch_size=5,   #
+    # and sleep_time_in_seconds=15 (as of December 2023.)                      #
+    ############################################################################
+    benchmark_df = await rag_evaluator.arun(
+        batch_size=20,  # batches the number of openai api calls to make
+        sleep_time_in_seconds=1,  # number of seconds sleep before making an api call
+    )
+    print(benchmark_df)
+
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main)

--- a/llama_hub/llama_datasets/docugami_kg_rag/sec_10_q/llamaindex_baseline.py
+++ b/llama_hub/llama_datasets/docugami_kg_rag/sec_10_q/llamaindex_baseline.py
@@ -9,7 +9,7 @@ from llama_index.llms import OpenAI
 async def main():
     # DOWNLOAD LLAMADATASET
     rag_dataset, documents = download_llama_dataset(
-        "DocugamiKGRAGSEC10Q", "./docugami_kg_rag_sec_10_q"
+        "DocugamiKgRagSec10Q", "./docugami_kg_rag_sec_10_q"
     )
 
     # BUILD BASIC RAG PIPELINE

--- a/llama_hub/llama_datasets/library.json
+++ b/llama_hub/llama_datasets/library.json
@@ -63,5 +63,10 @@
     "id": "llama_datasets/history_of_alexnet",
     "author": "CalculusC",
     "keywords": ["rag", "alexnet"]
+  },
+  "DocugamiKG-RAG-SEC10-Q": {
+    "id": "llama_datasets/docugami_kg_rag/sec_10_q",
+    "author": "Docugami",
+    "keywords": ["rag", "kg-rag", "10q", "docugami"]
   }
 }

--- a/llama_hub/llama_datasets/library.json
+++ b/llama_hub/llama_datasets/library.json
@@ -64,7 +64,7 @@
     "author": "CalculusC",
     "keywords": ["rag", "alexnet"]
   },
-  "DocugamiKGRAGSEC10Q": {
+  "DocugamiKgRagSec10Q": {
     "id": "llama_datasets/docugami_kg_rag/sec_10_q",
     "author": "Docugami",
     "keywords": ["rag", "kg-rag", "10q", "docugami"]

--- a/llama_hub/llama_datasets/library.json
+++ b/llama_hub/llama_datasets/library.json
@@ -64,7 +64,7 @@
     "author": "CalculusC",
     "keywords": ["rag", "alexnet"]
   },
-  "DocugamiKG-RAG-SEC10-Q": {
+  "DocugamiKGRAGSEC10Q": {
     "id": "llama_datasets/docugami_kg_rag/sec_10_q",
     "author": "Docugami",
     "keywords": ["rag", "kg-rag", "10q", "docugami"]


### PR DESCRIPTION
# Description

Added the docugami kg-rag dataset for SEC-10Q. You can read more here about the motivation for creating this dataset and how it was created: https://github.com/docugami/KG-RAG-datasets

The corresponding llama-datasets PR is: https://github.com/run-llama/llama-datasets/pull/43

## Type of Change

Please delete options that are not relevant.

- [x] New Dataset
- [ ] Bug fix / Smaller change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Suggested Checklist:

- [ ] I have added a library.json file if a new loader/tool was added
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods