### PR TITLE
revert list of names in authors; breaks ui

### DIFF
--- a/llama_hub/azstorage_blob/README.md
+++ b/llama_hub/azstorage_blob/README.md
@@ -63,3 +63,10 @@ documents = loader.load_data()
 ```
 
 This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/run-llama/llama_index/tree/main/llama_index) and/or subsequently used as a Tool in a [LangChain](https://github.com/hwchase17/langchain) Agent. See [here](https://github.com/emptycrown/llama-hub/tree/main) for examples.
+
+### Updates
+
+#### [2023-12-14] by [JAlexMcGraw](https://github.com/JAlexMcGraw) (#765)
+
+- Added functionality to allow user to connect to blob storage with connection string
+- Changed temporary file names from random to back to original names

--- a/llama_hub/library.json
+++ b/llama_hub/library.json
@@ -45,10 +45,7 @@
   },
   "AzStorageBlobReader": {
     "id": "azstorage_blob",
-    "author": [
-      "rivms", 
-      "JAlexMcGraw"
-    ],
+    "author": "rivms",
     "keywords": [
       "azure storage",
       "blob",


### PR DESCRIPTION
# Description

- Removes culprit entry in `library.json` where authors is entered as a list
    - this breaks the UI as it expects only a single string
- Added contribution details in README for the culprit loader 

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix / Smaller change


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense