### PR TITLE
Add Powerpoint Slide Loader PptxSlideReader to LLama-hub

### DIFF
--- a/llama_hub/file/pptx-slide/README.md
+++ b/llama_hub/file/pptx-slide/README.md
@@ -27,7 +27,7 @@ documents = loader.load_data(
 # Alternatively: documents = loader.load_data(file='./deck.pptx')
 ```
 
-This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/run-llama/llama_index/tree/main/llama_index) and/or subsequently used as a Tool in a [LangChain](https://github.com/hwchase17/langchain) Agent. See [here](https://github.com/emptycrown/llama-hub/tree/main) for examples.
+This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/run-llama/llama_index/tree/main/llama_index) and/or subsequently used as a Tool in a [LangChain](https://github.com/langchain-ai/langchain) Agent. See [here](https://github.com/run-llama/llama-hub/tree/main/llama_hub) for examples.
 
 ## FAQs
 

--- a/llama_hub/file/pptx-slide/README.md
+++ b/llama_hub/file/pptx-slide/README.md
@@ -1,0 +1,36 @@
+# Microsoft PowerPoint Slide Loader
+
+This loader reads a local Microsoft PowerPoint (.pptx) file and creates a list of Documents, each corresponding to a slide in the presentation.
+
+## Usage
+
+To use this loader, pass either a filename or a `Path` to a local file.
+
+**Parameters:**
+
+- file (required): Path to the PowerPoint file.
+- extra_info (optional): Additional information to be merged into the metadata of each document.
+- join_char (optional, default='\n'): Character used to join the text of shapes within a slide.
+- include_shapes (optional, default=False): If True, includes information about individual shapes in the metadata of each document.
+
+```python
+from pathlib import Path
+from llama_hub import PptxSlideReader
+
+loader = PptxSlideReader()
+documents = loader.load_data(
+  file=Path('./deck.pptx'),
+  extra_info={"source" : "my-deck.pptx"},
+  join_char='\n',
+  include_shapes=TRUE
+)
+# Alternatively: documents = loader.load_data(file='./deck.pptx')
+```
+
+This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/run-llama/llama_index/tree/main/llama_index) and/or subsequently used as a Tool in a [LangChain](https://github.com/hwchase17/langchain) Agent. See [here](https://github.com/emptycrown/llama-hub/tree/main) for examples.
+
+## FAQs
+
+### What is the difference with file/pptx loader?
+
+The file/pptx loader creates one Document that joins all the slides. In contrast, this file/pptx-slide loader creates a list of Documents corresponding to slides in the presentation.

--- a/llama_hub/file/pptx-slide/__init__.py
+++ b/llama_hub/file/pptx-slide/__init__.py
@@ -1,0 +1,6 @@
+"""Init file."""
+from llama_hub.file.pptx_slide.base import (
+    PptxSlideReader,
+)
+
+__all__ = ["PptxSlideReader"]

--- a/llama_hub/file/pptx-slide/base.py
+++ b/llama_hub/file/pptx-slide/base.py
@@ -1,0 +1,53 @@
+"""Read Microsoft PowerPoint files."""
+
+import os
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from llama_index.readers.base import BaseReader
+from llama_index.readers.schema.base import Document
+
+class PptxSlideReader(BaseReader):
+    """Powerpoint Slides Reader.
+
+    Create a list of Documents corresponding to the Slides of the presentation.
+
+    """
+    def __init__(self) -> None:
+        """Init reader."""
+
+    def load_data(
+        self,
+        file: Path or str,
+        extra_info: Optional[Dict] = None,
+    ) -> List[Document]:
+        """Load pptx file to create slide Documents"""
+        from pptx import Presentation
+        if isinstance(file, str):
+            file_path = Path(file)
+        else:
+            file_path = file
+
+        presentation = Presentation(file_path)
+        slide_docs = [
+            Document(
+                text = "\n".join([shape.text for shape in slide.shapes if hasattr(shape, "text")]),
+                extra_info = {
+                    "source": file_path.name,
+                    "shapes" : [
+                        {
+                            "text": shape.text, 
+                            "name": shape.name,
+                            "shape_id": shape.shape_id,
+                            "shape_type": shape.shape_type
+                        } 
+                        for shape in slide.shapes if hasattr(shape, "text")
+                    ]
+                }
+            ) 
+            for slide in presentation.slides
+            for shape in slide.shapes
+            if hasattr(shape, "text")
+        ]
+
+        return slide_docs

--- a/llama_hub/file/pptx-slide/base.py
+++ b/llama_hub/file/pptx-slide/base.py
@@ -6,12 +6,14 @@ from typing import Dict, List, Optional
 from llama_index.readers.base import BaseReader
 from llama_index.readers.schema.base import Document
 
+
 class PptxSlideReader(BaseReader):
     """Powerpoint Slides Reader.
 
     Create a list of Documents corresponding to the Slides of the presentation.
 
     """
+
     def __init__(self) -> None:
         """Init reader."""
 
@@ -22,6 +24,7 @@ class PptxSlideReader(BaseReader):
     ) -> List[Document]:
         """Load pptx file to create slide Documents"""
         from pptx import Presentation
+
         if isinstance(file, str):
             file_path = Path(file)
         else:
@@ -30,20 +33,23 @@ class PptxSlideReader(BaseReader):
         presentation = Presentation(file_path)
         slide_docs = [
             Document(
-                text = "\n".join([shape.text for shape in slide.shapes if hasattr(shape, "text")]),
-                extra_info = {
+                text="\n".join(
+                    [shape.text for shape in slide.shapes if hasattr(shape, "text")]
+                ),
+                extra_info={
                     "source": file_path.name,
-                    "shapes" : [
+                    "shapes": [
                         {
-                            "text": shape.text, 
+                            "text": shape.text,
                             "name": shape.name,
                             "shape_id": shape.shape_id,
-                            "shape_type": shape.shape_type
-                        } 
-                        for shape in slide.shapes if hasattr(shape, "text")
-                    ]
-                }
-            ) 
+                            "shape_type": shape.shape_type,
+                        }
+                        for shape in slide.shapes
+                        if hasattr(shape, "text")
+                    ],
+                },
+            )
             for slide in presentation.slides
             for shape in slide.shapes
             if hasattr(shape, "text")

--- a/llama_hub/file/pptx-slide/base.py
+++ b/llama_hub/file/pptx-slide/base.py
@@ -1,6 +1,5 @@
 """Read Microsoft PowerPoint files."""
 
-import os
 from pathlib import Path
 from typing import Dict, List, Optional
 

--- a/llama_hub/file/pptx-slide/requirements.txt
+++ b/llama_hub/file/pptx-slide/requirements.txt
@@ -1,0 +1,1 @@
+python-pptx

--- a/llama_hub/library.json
+++ b/llama_hub/library.json
@@ -94,6 +94,10 @@
     "id": "file/pptx",
     "author": "thejessezhang"
   },
+  "PptxSlideReader": {
+    "id": "file/pptx-slide",
+    "author": "tewnut"
+  },
   "ImageReader": {
     "id": "file/image",
     "author": "ravi03071991",
@@ -128,7 +132,7 @@
   "MainContentExtractorReader": {
     "id": "web/main_content_extractor",
     "author": "HawkClaws",
-    "keywords":[
+    "keywords": [
       "main content extractor",
       "web",
       "web reader"
@@ -625,7 +629,7 @@
     "keywords": [
       "preprocess",
       "chunking",
-      "chunk", 
+      "chunk",
       "documents"
     ]
   },
@@ -956,11 +960,16 @@
   "ZepReader": {
     "id": "zep",
     "author": "zep",
-    "keywords": ["zep", "retriever", "memory", "storage"]
+    "keywords": [
+      "zep",
+      "retriever",
+      "memory",
+      "storage"
+    ]
   },
   "MacrometaGDNReader": {
-  	"id": "macrometa_gdn",
-  	"author": "Dain Im",
+    "id": "macrometa_gdn",
+    "author": "Dain Im",
     "keywords": [
       "macrometa"
     ]
@@ -1011,15 +1020,15 @@
     "id": "lilac_reader",
     "author": "nsthorat"
   },
-  "IMDBReviews":{
+  "IMDBReviews": {
     "id": "imdb_review",
     "author": "Athe-kunal",
-    "keywords":[
+    "keywords": [
       "movies",
       "reviews",
       "IMDB"
-  ]
-},
+    ]
+  },
   "PDFNougatOCR": {
     "id": "nougat_ocr",
     "author": "mdarshad1000",
@@ -1029,10 +1038,10 @@
       "academic papers"
     ]
   },
-  "BitbucketReader":{
+  "BitbucketReader": {
     "id": "bitbucket",
     "author": "lejdiprifti",
-    "keywords":[
+    "keywords": [
       "bitbucket",
       "project",
       "repository"
@@ -1068,7 +1077,9 @@
   "PatentsviewReader": {
     "id": "patentsview",
     "author": "shao-shuai",
-    "keywords": ["patent"]
+    "keywords": [
+      "patent"
+    ]
   },
   "SmartPDFLoader": {
     "id": "smart_pdf_loader",
@@ -1104,7 +1115,7 @@
   "TrafilaturaWebReader": {
     "id": "web/trafilatura_web",
     "author": "NA",
-    "keywords":[
+    "keywords": [
       "trafilatura",
       "web",
       "web reader"
@@ -1113,13 +1124,13 @@
   "StripeDocsReader": {
     "id": "stripe_docs",
     "author": "amorriscode",
-    "keywords":[
+    "keywords": [
       "stripe",
       "documentation"
     ]
   },
-  "EarningsCallTranscript":{
-    "id":"earnings_call_transcript",
+  "EarningsCallTranscript": {
+    "id": "earnings_call_transcript",
     "author": "Athe-kunal",
     "keywords": [
       "Finance",
@@ -1140,10 +1151,10 @@
       "HDFS"
     ]
   },
-  "SharePointReader":{
+  "SharePointReader": {
     "id": "microsoft_sharepoint",
     "author": "arun-soliton",
-    "keywords":[
+    "keywords": [
       "sharepoint",
       "microsoft 365",
       "microsoft365"


### PR DESCRIPTION
# Description
This is a new loader to read a PowerPoint presentation file and create a list of slide Documents.

## Type of Change
Please delete options that are not relevant.
- [x] New Loader/Tool. 

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] Added new notebook (that tests end-to-end). [Link to the notebook](https://colab.research.google.com/drive/14SQJ-Sccgpt1U_q5_dmj6uTrKXZbZTAN?usp=sharing)

# Suggested Checklist:
- [x] I have added a library.json file if a new loader/tool was added
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes