### PR TITLE
Create PDFPlumberReader

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ python3.9 -m venv .venv
 source .venv/bin/activate 
 pip3 install -r test_requirements.txt
 
-poetry run pytest tests 
+poetry run make test
 ```
 
 ## Changelog

--- a/llama_hub/file/pdf_plumber/README.md
+++ b/llama_hub/file/pdf_plumber/README.md
@@ -1,0 +1,19 @@
+# PDF Loader
+
+This loader extracts the text from a local PDF file using the `pdfplumber` Python package. Any non-text elements are ignored. A single local file is passed in each time you call `load_data`.
+This package often pulls text data much more cleanly than the builtin `pypdf` parser, albeit somewhat slower.
+
+## Usage
+
+To use this loader, you need to pass in the local path to the file, as a string, to the `load_data()` method.
+
+```python
+from llama_index import download_loader
+
+PDFPlumberReader = download_loader("PDFPlumberReader")
+
+loader = PDFPlumberReader()
+documents = loader.load_data(file='./article.pdf')
+```
+
+This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/run-llama/llama_index/tree/main/llama_index) and/or subsequently used as a Tool in a [LangChain](https://github.com/hwchase17/langchain) Agent. See [here](https://github.com/emptycrown/llama-hub/tree/main) for examples.

--- a/llama_hub/file/pdf_plumber/__init__.py
+++ b/llama_hub/file/pdf_plumber/__init__.py
@@ -1,0 +1,6 @@
+"""Init file."""
+from llama_hub.file.pdf_miner.base import (
+    PDFPlumberReader,
+)
+
+__all__ = ["PDFPlumberReader"]

--- a/llama_hub/file/pdf_plumber/__init__.py
+++ b/llama_hub/file/pdf_plumber/__init__.py
@@ -1,5 +1,5 @@
 """Init file."""
-from llama_hub.file.pdf_miner.base import (
+from llama_hub.file.pdf_plumber.base import (
     PDFPlumberReader,
 )
 

--- a/llama_hub/file/pdf_plumber/base.py
+++ b/llama_hub/file/pdf_plumber/base.py
@@ -1,0 +1,33 @@
+""""Read PDF files using pdfplumber"""
+from typing import Dict, List, Optional
+
+from llama_index.readers.base import BaseReader
+from llama_index.schema import Document
+
+
+class PDFPlumberReader(BaseReader):
+    """PDF parser."""
+
+    def load_data(self, file: str, extra_info: Optional[Dict] = None) -> List[Document]:
+        """Parse file."""
+
+        docs = []
+
+        try:
+            import pdfplumber
+        except ImportError:
+            raise ImportError(
+                "pdfplumber is required to read PDF files: `pip install pdfplumber`"
+            )
+        with pdfplumber.open(file) as fp:
+            text_list = [page.extract_text() for page in fp.pages]
+            text = "\n".join(text_list)
+            metadata = {"file_path": fp.stream.name}
+
+            if extra_info is not None:
+                metadata.update(extra_info)
+
+            docs.append(Document(text=text, metadata=metadata))
+            fp.close()
+
+        return docs

--- a/llama_hub/file/pdf_plumber/requirements.txt
+++ b/llama_hub/file/pdf_plumber/requirements.txt
@@ -1,0 +1,1 @@
+pdfplumber

--- a/llama_hub/library.json
+++ b/llama_hub/library.json
@@ -619,6 +619,14 @@
       "pdf"
     ]
   },
+  "PDFPlumberReader": {
+    "id": "file/pdf_plumber",
+    "author": "JAlexMcGraw",
+    "keywords": [
+      "pdf",
+      "reader"
+    ]
+  },
   "PreprocessReader": {
     "id": "preprocess",
     "author": "preprocess",


### PR DESCRIPTION
# Description

Created the PDFPlumberReader class, and the associated needed files. Also updated the main README, to let users know to run `poetry run make test`, because the prior CLI run didn't work. 

Motivation to create this is because the builtin PDFReader did not read text as well as PDFPlumber package. Lots of words ended up split in half, or missing. 

Required install of pdfplumber to run this. 

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] New Loader/Tool
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [x] Used current unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have added a library.json file if a new loader/tool was added
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods