### PR TITLE
fix: Add UTF-8 decoding for cursor to _get_cql_data_with_paging

### DIFF
--- a/llama_hub/confluence/base.py
+++ b/llama_hub/confluence/base.py
@@ -2,6 +2,7 @@
 import logging
 import os
 from typing import Dict, List, Optional
+from urllib.parse import unquote
 
 from llama_index.readers.base import BaseReader
 from llama_index.readers.schema.base import Document
@@ -274,7 +275,7 @@ class ConfluenceReader(BaseReader):
         ret = []
         params = {"cql": cql, "start": start, "expand": expand}
         if cursor:
-            params["cursor"] = cursor
+            params["cursor"] = unquote(cursor)
 
         if max_num_results is not None:
             params["limit"] = max_num_remaining
@@ -295,7 +296,7 @@ class ConfluenceReader(BaseReader):
 
             if "cursor=" in next_url:  # On confluence Server this is not set
                 cursor = next_url.split("cursor=")[1].split("&")[0]
-                params["cursor"] = cursor
+                params["cursor"] = unquote(cursor)
 
             if max_num_results is not None:
                 params["limit"] -= len(results["results"])


### PR DESCRIPTION
We were getting this error from Atlassian API:

```
[knowledgegpt-f48c7d9c4-wczn6 knowledgegpt] {"time": "2023-11-01 15:38:31,568", "level": "ERROR", "message": "com.atlassian.confluence.api.service.exceptions.SSStatusCodeException: CQL was parsed but the search manager was unable to execute the search. Error message: com.atlassian.confluence.api.service.exceptions.SSStatusCodeException: There was an illegal request passed to XP-Search Aggregator API : HTTP/1.1 400 Bad Request"}
```
After some investigation, I found this URL as an example:

https://OURORGANIZATION.atlassian.net/wiki/rest/api/content/search?cql=type=%22page%22+AND+label=%22knowledgegpt%22&start=50&expand=body.storage.value&limit=150&cursor=_f_NTA%253D_sa_WyJcdDYyNDE5NzYzMyA5WG87aF1yWFQtUUk4RVU4QGdpUyBjcCJd

In this URL we have %25 in the cursor that is UTF-8 encoding for % character and that is causing the error.