### PR TITLE
Correct import of Llama-Pack in Usage example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ llamaindex-cli download-llamapack ZephyrQueryEnginePack --download-dir ./zephyr_
 Or with the `download_llama_pack` function directly:
 
 ```python
-from llama_index.llama_packs import download_llama_pack
+from llama_index.llama_pack import download_llama_pack
 
 # download and install dependencies
 LlavaCompletionPack = download_llama_pack(


### PR DESCRIPTION
llama_index.llama_packs updated to llama_index.llama_pack

# Description

Updated the section [Llama-Pack usage](https://github.com/run-llama/llama-hub?tab=readme-ov-file#llama-pack-usage) in documentation, current example has a typo (packs instead of pack) and module import fails.

Current -

from llama_index.llama_packs import download_llama_pack

Updated:

from llama_index.llama_pack import download_llama_pack

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] New Loader/Tool
- [x] Bug fix / Smaller change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have added a library.json file if a new loader/tool was added
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods