### PR TITLE
Fixing JsonReader and introducing unit tests

### DIFF
--- a/tests/file/json/test_json.py
+++ b/tests/file/json/test_json.py
@@ -1,0 +1,58 @@
+import json
+import pytest
+
+from llama_hub.file.json import JSONReader
+
+# Sample JSON data for testing
+SAMPLE_JSON = {
+    "name": "John Doe",
+    "age": 30,
+    "address": {"street": "123 Main St", "city": "Anytown", "state": "CA"},
+}
+
+SAMPLE_JSONL = [json.dumps(SAMPLE_JSON), json.dumps({"name": "Jane Doe", "age": 25})]
+
+# Fixture to create a temporary JSON file
+@pytest.fixture
+def json_file(tmp_path):
+    file = tmp_path / "test.json"
+    with open(file, "w") as f:
+        json.dump(SAMPLE_JSON, f)
+    return file
+
+
+# Fixture to create a temporary JSONL file
+@pytest.fixture
+def jsonl_file(tmp_path):
+    file = tmp_path / "test.jsonl"
+    with open(file, "w") as f:
+        f.write("\n".join(SAMPLE_JSONL))
+    return file
+
+
+def test_json_reader_init():
+    reader = JSONReader(levels_back=2)
+    assert reader.levels_back == 2
+
+
+def test_parse_jsonobj_to_document():
+    reader = JSONReader()
+    document = reader._parse_jsonobj_to_document(SAMPLE_JSON)
+    assert "John Doe" in document.text
+    assert "30" in document.text
+
+
+def test_load_data_json(json_file):
+    reader = JSONReader()
+    documents = reader.load_data(json_file)
+    assert len(documents) == 1
+    assert "John Doe" in documents[0].text
+    assert "123 Main St" in documents[0].text
+
+
+def test_load_data_jsonl(jsonl_file):
+    reader = JSONReader()
+    documents = reader.load_data(jsonl_file, is_jsonl=True)
+    assert len(documents) == 2
+    assert "Jane Doe" in documents[1].text
+    assert "25" in documents[1].text


### PR DESCRIPTION
# Description

The JsonReader is currently not working. It only considers the Keys and ignores the content in Value. This is fixed in the PR, and also Unit tests are introduced to validate any further changes.

Fixes # [(issue)](https://github.com/run-llama/llama-hub/issues/606)
Related to: https://github.com/run-llama/llama-hub/pull/485

### Issue:

1. Change was done in PR [(485)](https://github.com/run-llama/llama-hub/pull/485) to accommodate a schema that seems to be not json syntax compliant.

![json-syntax-incorrect](https://github.com/run-llama/llama-hub/assets/12369322/f5f3bbd7-ae92-49b5-8393-5f52086cc4c5)

2. For syntactically accurate Json the actual value is missing and instead only the keys are present in the document  Refer https://github.com/run-llama/llama-hub/issues/606 .

3. The line causing the issue (only dictionary keys are returned): https://github.com/run-llama/llama-hub/blob/c36cdc54b82ced1bffe792293d896ca5681a2e61/llama_hub/file/json/base.py#L79

### Solution
This is a PR to fix this, with syntactically accurate JSON retaining its original behavior of being passed entirely as single document. If multiple documents are required then a list of JSONobjects or JSONL needs to be passed.


## Type of Change

Please delete options that are not relevant.

- [ ] New Loader/Tool
- [x] Bug fix / Smaller change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have added a library.json file if a new loader/tool was added
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods