### PR TITLE
Slack Tool: Fix "fn_schema is None" issue

### DIFF
--- a/llama_hub/tools/slack/base.py
+++ b/llama_hub/tools/slack/base.py
@@ -77,14 +77,14 @@ class SlackToolSpec(BaseToolSpec):
         """Send a message to a channel given the channel ID."""
         slack_client = self.reader.client
         try:
-            msg_result = slack_client.chat_postMessage(
+            # TODO: Consider adding the result into `MessageSenderOutput`.
+            slack_client.chat_postMessage(
                 channel=channel_id,
                 text=message,
             )
         except Exception as e:
             logger.error(e)
             raise e
-        # TODO: Consider adding `slack_response=msg_result` into `MessageSenderOutput`.
         return MessageSenderOutput()
 
     def fetch_channels(

--- a/llama_hub/tools/slack/base.py
+++ b/llama_hub/tools/slack/base.py
@@ -9,7 +9,6 @@ from llama_index.readers.schema.base import Document
 from llama_index.readers.slack import SlackReader
 from llama_index.tools.tool_spec.base import BaseToolSpec
 from pydantic import BaseModel
-from slack_sdk.web import SlackResponse
 
 logger = logging.getLogger(__name__)
 
@@ -19,8 +18,10 @@ class DataLoaderOutput(BaseModel):
 
 
 class MessageSenderOutput(BaseModel):
-    # TODO: RuntimeError: no validator found for <class 'slack_sdk.web.slack_response.SlackResponse'>, see `arbitrary_types_allowed` in Config
-    pass  # slack_response: SlackResponse
+    # TODO: Once we have a Pydantic definition for `slack_sdk.web.SlackResponse`, we can make this more useful.
+    # Today, if we add `slack_response: SlackResponse` here, it will give RuntimeError:
+    # no validator found for <class 'slack_sdk.web.slack_response.SlackResponse'>, see `arbitrary_types_allowed` in Config
+    pass
 
 
 class ChannelFetcherOutput(BaseModel):

--- a/llama_hub/tools/slack/base.py
+++ b/llama_hub/tools/slack/base.py
@@ -83,7 +83,8 @@ class SlackToolSpec(BaseToolSpec):
         except Exception as e:
             logger.error(e)
             raise e
-        return MessageSenderOutput(slack_response=msg_result)
+        # TODO: Consider adding `slack_response=msg_result` into `MessageSenderOutput`.
+        return MessageSenderOutput()
 
     def fetch_channels(
         self,


### PR DESCRIPTION
# Description

All 3 functions were missing schema. This PR adds them.

Fixes https://github.com/run-llama/llama_index/issues/9732

## Type of Change

Please delete options that are not relevant.

- [ ] New Loader/Tool
- [x] Bug fix / Smaller change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I tested with a LlamaIndex + ChainLit + GPT 3.5 application running locally. As shown below, the LLM can now call the function without complaining `ValueError: fn_schema is None`.

<table>
<tr>
 <td>before
 <td>after
<tr>
 <td><img width="799" alt="before" src="https://github.com/run-llama/llama-hub/assets/594058/0e9a455f-2e84-4803-8a0f-d939c94ba160">
 <td><img width="865" alt="after" src="https://github.com/run-llama/llama-hub/assets/594058/6e294105-bfe5-43d4-b602-f98409728451">
</table>

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have added a library.json file if a new loader/tool was added
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods