### PR TITLE
Wikipedia tools should return text, not documents (Tools aren't DataLoaders!)

### DIFF
--- a/llama_hub/tools/wikipedia/base.py
+++ b/llama_hub/tools/wikipedia/base.py
@@ -1,46 +1,42 @@
 """Wikipedia tool spec."""
 
-from typing import Any, List
+from typing import Any, Dict
 
 from llama_index.readers.schema.base import Document
 from llama_index.tools.tool_spec.base import BaseToolSpec
 
 
 class WikipediaToolSpec(BaseToolSpec):
-    """Wikipedia tool spec.
-
-    Currently a simple wrapper around the data loader.
-
+    """
+    Specifies two tools for querying information from Wikipedia.
     """
 
     spec_functions = ["load_data", "search_data"]
 
     def load_data(
-        self, pages: List[str], lang: str = "en", **load_kwargs: Any
-    ) -> List[Document]:
-        """Load data from wikipedia.
+        self, page: str, lang: str = "en", **load_kwargs: Dict[str, Any]
+    ) -> str:
+        """
+        Retrieve a Wikipedia page. Useful for learning about a particular concept that isn't private information.
 
         Args:
-            pages (List[str]): List of pages to read.
-            lang  (str): language of wikipedia texts (default English)
+            page (str): Title of the page to read.
+            lang (str): Language of Wikipedia to read. (default: English)
         """
         import wikipedia
-        from wikipedia import PageError
-
+        wikipedia.set_lang(lang)
         try:
-            results = []
-            for page in pages:
-                wikipedia.set_lang(lang)
-                page_content = wikipedia.page(
-                    page, **load_kwargs, auto_suggest=False
-                ).content
-                results.append(Document(text=page_content))
-            return results
-        except PageError:
+            wikipedia_page = wikipedia.page(
+                page, **load_kwargs, auto_suggest=False
+            )
+        except wikipedia.PageError:
             return "Unable to load page. Try searching instead."
+        return wikipedia_page.content
 
-    def search_data(self, query: str, lang: str = "en") -> List[Document]:
-        """Searchs wikipedia for pages related to a query. Use this endpoint when load_data returns no results.
+    def search_data(self, query: str, lang: str = "en") -> str:
+        """
+        Search Wikipedia for a page related to the given query.
+        Use this tool when `load_data` returns no results.
 
         Args:
             query (str): the string to search for
@@ -49,5 +45,5 @@ class WikipediaToolSpec(BaseToolSpec):
 
         pages = wikipedia.search(query)
         if len(pages) == 0:
-            return "Unable to find any details on this search"
-        return self.load_data(pages, lang)
+            return "No search results."
+        return self.load_data(pages[0], lang)

--- a/llama_hub/tools/wikipedia/base.py
+++ b/llama_hub/tools/wikipedia/base.py
@@ -2,7 +2,6 @@
 
 from typing import Any, Dict
 
-from llama_index.readers.schema.base import Document
 from llama_index.tools.tool_spec.base import BaseToolSpec
 
 

--- a/llama_hub/tools/wikipedia/base.py
+++ b/llama_hub/tools/wikipedia/base.py
@@ -23,11 +23,10 @@ class WikipediaToolSpec(BaseToolSpec):
             lang (str): Language of Wikipedia to read. (default: English)
         """
         import wikipedia
+
         wikipedia.set_lang(lang)
         try:
-            wikipedia_page = wikipedia.page(
-                page, **load_kwargs, auto_suggest=False
-            )
+            wikipedia_page = wikipedia.page(page, **load_kwargs, auto_suggest=False)
         except wikipedia.PageError:
             return "Unable to load page. Try searching instead."
         return wikipedia_page.content


### PR DESCRIPTION
# Description

IMO, a tool should work differently from a Data Loader. A tool should return the content, and just the content, if possible.
It should not expose to the LLM the fact that it is a Python program. The original implementation gives off the lower-level details to the LLM by emitting characters like these in the Observation:

```
[Document(id_='ea46abda-4165-4ba1-8cc6-36b0e681c0c5', embedding=None, metadata={}, excluded_embed_metadata_keys=[], excluded_llm_metadata_keys=[], relationships={}, hash='735a0b01227b2ff21ece7f97445fbb9816668aee7922123966d16e057b0a1268', text='
```

This PR thrives to fix that. Here's a demo:

Before:

```
    {
      "role": "user",
      "content": "Look up cheesecakes on Wikipedia."
    },
    {
      "role": "assistant",
      "content": "Thought: I need to use a tool to help me find information about cheesecakes.\nAction: load_data\nAction Input: {'pages': ['Cheesecake']}"
    },
    {
      "role": "user",
      "content": "Observation: [Document(id_='ea46abda-4165-4ba1-8cc6-36b0e681c0c5', embedding=None, metadata={}, excluded_embed_metadata_keys=[], excluded_llm_metadata_keys=[], relationships={}, hash='735a0b01227b2ff21ece7f97445fbb9816668aee7922123966d16e057b0a1268', text='Cheesecake is a dessert made with a soft fresh cheese
```

After:

```
    {
      "role": "user",
      "content": "Summarize Wikipedia page on Wellerism."
    },
    {
      "role": "assistant",
      "content": "Thought: I need to use a tool to help me answer the question.\nAction: load_data\nAction Input: {'page': 'Wellerism', 'lang': 'en'}"
    },
    {
      "role": "user",
      "content": "Observation: Wellerisms, named after sayings of Sam Weller in Charles Dickens's novel
```

I also don't think it's wise to load multiple pages with this tool, because each Wikipedia page alone is prone to exceed the context window of the LLM. Plus, the document separators would be too tiny for the LLM to notice. Most importantly, the multi-page support just doesn't match the README!

## Type of Change

Please delete options that are not relevant.

- [ ] New Loader/Tool
- [x] Bug fix / Smaller change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have added a library.json file if a new loader/tool was added
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods