### PR TITLE
Fix:dense pack naming error in readme file.

### DIFF
--- a/llama_hub/llama_packs/dense_x_retrieval/README.md
+++ b/llama_hub/llama_packs/dense_x_retrieval/README.md
@@ -46,7 +46,7 @@ dense_pack = DenseXRetrievalPack(documents)
 The `run()` function is a light wrapper around `query_engine.query()`. 
 
 ```python
-response = fuzzy_engine.run("What can you tell me about LLMs?")
+response = dense_pack.run("What can you tell me about LLMs?")
 
 print(response)
 ```


### PR DESCRIPTION
# Description

PR to fix `dense_pack.run(<query>)` naming error in readme file.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix / Smaller change

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have added a library.json file if a new loader/tool was added
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods