### PR TITLE
Handle bytestrings in PDF reader

### DIFF
--- a/llama_hub/file/pdf/README.md
+++ b/llama_hub/file/pdf/README.md
@@ -4,7 +4,7 @@ This loader extracts the text from a local PDF file using the `PyPDF2` Python pa
 
 ## Usage
 
-To use this loader, you need to pass in a `Path` to a local file.
+To use this loader, you need to pass in a `Path` to a local file or a PDF byte stream.
 
 ```python
 from pathlib import Path

--- a/llama_hub/file/pdf/base.py
+++ b/llama_hub/file/pdf/base.py
@@ -21,7 +21,14 @@ class PDFReader(BaseReader):
             file = Path(file)
 
         # Open the file if it's not already open, else use it as it is
-        context = open(file, "rb") if isinstance(file, Path) else file
+        if isinstance(file, Path):
+            context = open(file, "rb")
+            if extra_info:
+                extra_info.update({"file_name": file.name})
+            else:
+                extra_info = {"file_name": file.name}
+        else:
+            context = file
 
         with context as fp:
             # Create a PDF object
@@ -36,7 +43,7 @@ class PDFReader(BaseReader):
                 # Extract the text from the page
                 page_text = pdf.pages[page].extract_text()
                 page_label = pdf.page_labels[page]
-                metadata = {"page_label": page_label, "file_name": file.name}
+                metadata = {"page_label": page_label}
 
                 if extra_info is not None:
                     metadata.update(extra_info)


### PR DESCRIPTION
# Description

A fix for the PDFReader to handle reading files as bytestrings. The loader already supported that function but there was a small bug related to the fact that it expected a file name to be fetched which is not available when passing a pdf bystring. This PR addresses this. The file name can still be added manually using the `extra_info` argument.

PDF bytestrings can be useful in case the user wants to load in case a user uses a custom filesystem interface like fsspec

example:
```python
# Create the GCS file system
gcs = fsspec.filesystem('gcs')

# Open and read the PDF file from GCS
with gcs.open(f'{bucket_name}/{file_path}', 'rb') as file:
    pdf_content = BytesIO(file.read())
```

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] New Loader/Tool
- [X] Bug fix / Smaller change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I ran the class locally with different file inputs (path to pdf, pdf bytestrings)

# Suggested Checklist:

- [ ] I have added a library.json file if a new loader/tool was added
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods