### PR TITLE
use os.path.join to generate file paths

### DIFF
--- a/llama_hub/azstorage_blob/base.py
+++ b/llama_hub/azstorage_blob/base.py
@@ -7,6 +7,7 @@ import logging
 import math
 import tempfile
 import time
+import os
 from typing import Any, Dict, List, Optional, Union
 
 from llama_index import download_loader
@@ -89,7 +90,7 @@ class AzStorageBlobReader(BaseReader):
             if self.blob:
                 blob_client = container_client.get_blob_client(self.blob)
                 stream = blob_client.download_blob()
-                download_file_path = f"{temp_dir}/{stream.name}"
+                download_file_path = os.path.join(temp_dir, stream.name)
                 logger.info(f"Start download of {self.blob}")
                 start_time = time.time()
                 with open(file=download_file_path, mode="wb") as download_file:
@@ -107,7 +108,7 @@ class AzStorageBlobReader(BaseReader):
                     self.name_starts_with, self.include
                 )
                 for obj in blobs_list:
-                    download_file_path = f"{temp_dir}/{obj.name}"
+                    download_file_path = os.path.join(temp_dir, obj.name)
                     logger.info(f"Start download of {obj.name}")
                     start_time = time.time()
                     blob_client = container_client.get_blob_client(obj)


### PR DESCRIPTION
# Description

Utilize os.path.join to create OS agnostic file paths

Fixes # [865](https://github.com/run-llama/llama-hub/issues/865)

## Type of Change

Please delete options that are not relevant.

- [ ] New Loader/Tool
- [X] Bug fix / Smaller change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran code locally to verify that files were successfully indexed using the AzStorageBlobReader

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have added a library.json file if a new loader/tool was added
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods