### PR TITLE
MangaDex Loader

### DIFF
--- a/llama_hub/library.json
+++ b/llama_hub/library.json
@@ -134,6 +134,14 @@
     "id": "jsondata",
     "author": "jerryjliu"
   },
+  "MangaDexReader": {
+    "id": "mangadex",
+    "author": "choombaa",
+    "keywords": [
+      "manga",
+      "anime"
+    ]
+  },
   "MarkdownReader": {
     "id": "file/markdown",
     "author": "hursh-desai"

--- a/llama_hub/mangadex/README.md
+++ b/llama_hub/mangadex/README.md
@@ -1,0 +1,37 @@
+# MangaDex Loader
+
+This loader fetches information from the MangaDex API, by manga title.
+
+## Usage
+
+```python
+from llama_index import download_loader
+
+MangaDexReader = download_loader('MangaDexReader')
+
+loader = MangaDexReader()
+documents = loader.load_data(titles=['manga title 1', 'manga title 2'], lang="en")
+```
+
+## Output
+
+### Text
+
+Document text is the manga title. There are alternate titles for many manga, so the canonical title will be returned, even if it is not the title that the user queried with.
+
+### Extra Info
+
+| Data | Description |
+|------|-------------|
+| id (str) | MangaDex manga id |
+| author (str) | Author's full name |
+| artist (str) | Artist's full name |
+| description (str) | Manga description |
+| original_language (str) | The language of the source material (before translation) |
+| tags (List[str]) | Describes the manga's genre, e.g. "slice of life" |
+| chapter_count (int)| How many chapters exist in the requested language |
+| latest_chapter_published_at (str)| Timestamp (YYYY-MM-DDTHH:MM:SS in timezone UTC+0) for the latest chapter in the requested language |
+
+## Examples
+
+This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/run-llama/llama_index/tree/main/llama_index) and/or subsequently used as a Tool in a [LangChain](https://github.com/hwchase17/langchain) Agent.

--- a/llama_hub/mangadex/__init__.py
+++ b/llama_hub/mangadex/__init__.py
@@ -1,0 +1,4 @@
+"""Init file."""
+from llama_hub.mangadex.base import MangaDexReader
+
+__all__ = ["MangaDexReader"]

--- a/llama_hub/mangadex/base.py
+++ b/llama_hub/mangadex/base.py
@@ -1,0 +1,133 @@
+"""
+MangaDex info reader
+
+Retrieves data about a particular manga by title.
+"""
+
+from typing import List
+import logging
+import requests
+from llama_index.readers.base import BaseReader
+from llama_index.readers.schema.base import Document
+
+logger = logging.getLogger(__name__)
+
+
+class MangaDexReader(BaseReader):
+    def __init__(self):
+        self.base_url = "https://api.mangadex.org"
+
+    def _get_manga_info(self, title: str):
+        try:
+            manga_response = requests.get(
+                f"{self.base_url}/manga", params={"title": title}
+            )
+            manga_response.raise_for_status()
+            manga_data = manga_response.json()["data"]
+
+            if len(manga_data):
+                return manga_data[0]
+            else:
+                logger.warning(f"No match found for title '{title}'")
+                return None
+        except requests.exceptions.HTTPError as http_error:
+            logger.error(f"HTTP error: {http_error}")
+        except requests.exceptions.RequestException as req_error:
+            logger.error(f"Request Error: {req_error}")
+        return None
+
+    # Authors and artists are combined
+    def _get_manga_author(self, id: str):
+        try:
+            author_response = requests.get(
+                f"{self.base_url}/author", params={"ids[]": [id]}
+            )
+            author_response.raise_for_status()
+            author = author_response.json()["data"][0]
+
+            return author
+        except requests.exceptions.HTTPError as http_error:
+            logger.error(f"HTTP error: {http_error}")
+        except requests.exceptions.RequestException as req_error:
+            logger.error(f"Request Error: {req_error}")
+        return None
+
+    def _get_manga_chapters(self, manga_id: str, lang: str):
+        try:
+            chapter_response = requests.get(
+                f"{self.base_url}/manga/{manga_id}/feed",
+                params={
+                    "translatedLanguage[]": [lang],
+                    "order[chapter]": "asc",
+                },
+            )
+            chapter_response.raise_for_status()
+            chapters = chapter_response.json()
+
+            return chapters
+        except requests.exceptions.HTTPError as http_error:
+            logger.error(f"HTTP error: {http_error}")
+        except requests.exceptions.RequestException as req_error:
+            logger.error(f"Request Error: {req_error}")
+        return None
+
+    def load_data(self, titles: List[str], lang: str = "en") -> List[Document]:
+        """Load data from the MangaDex API.
+        Args:
+            title (List[str]): List of manga titles
+            lang (str, optional): ISO 639-1 language code. Defaults to 'en'.
+        Returns:
+            List[Document]: A list of Documents.
+
+        """
+        result = []
+        for title in titles:
+            manga = self._get_manga_info(title)
+            if not manga:
+                continue
+
+            author_name, artist_name = None, None
+            for r in manga["relationships"]:
+                if r["type"] == "author":
+                    author = self._get_manga_author(r["id"])
+                    author_name = author["attributes"]["name"]
+                if r["type"] == "artist":
+                    artist = self._get_manga_author(r["id"])
+                    artist_name = artist["attributes"]["name"]
+
+            chapters = self._get_manga_chapters(manga["id"], lang)
+            chapter_count = chapters.get("total", None)
+            latest_chapter_published_at = None
+            if len(chapters["data"]):
+                latest_chapter = chapters["data"][-1]
+                latest_chapter_published_at = latest_chapter["attributes"]["publishAt"]
+
+            # Get tags for the selected language
+            tags = []
+            for tag in manga["attributes"]["tags"]:
+                tag_name_dict = tag["attributes"]["name"]
+                if lang in tag_name_dict:
+                    tags.append(tag_name_dict[lang])
+
+            doc = Document(
+                text=manga["attributes"]["title"].get(lang, title),
+                extra_info={
+                    "id": manga["id"],
+                    "author": author_name,
+                    "artist": artist_name,
+                    "description": manga["attributes"]["description"].get(lang, None),
+                    "original_language": manga["attributes"]["originalLanguage"],
+                    "tags": tags,
+                    "chapter_count": chapter_count,
+                    "latest_chapter_published_at": latest_chapter_published_at,
+                },
+            )
+            result.append(doc)
+
+        return result
+
+
+if __name__ == "__main__":
+    reader = MangaDexReader()
+
+    print(reader.load_data(titles=["Grand Blue Dreaming"], lang="en"))


### PR DESCRIPTION
Added MangaDexReader, which loads documents from the MangaDex API.

# Description

This loader fetches information from the MangaDex API

![Screenshot from 2024-01-16 16-37-57](https://github.com/run-llama/llama-hub/assets/137384389/d05d01ee-fc79-45bb-abc6-c4157178bc0c)

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] New Loader/Tool

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have added a library.json file if a new loader/tool was added
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods