### PR TITLE
Add timeout arg to github repo reader

### DIFF
--- a/llama_hub/github_repo/README.md
+++ b/llama_hub/github_repo/README.md
@@ -29,6 +29,7 @@ loader = GithubRepositoryReader(
     filter_file_extensions = ([".py"], GithubRepositoryReader.FilterType.INCLUDE),
     verbose =                True,
     concurrent_requests =    10,
+    timeout =                5,
 )
 
 docs = loader.load_data(branch="main")
@@ -74,6 +75,7 @@ if docs is None:
         filter_file_extensions = ([".py"], GithubRepositoryReader.FilterType.INCLUDE),
         verbose =                True,
         concurrent_requests =    10,
+        timeout =                5,
     )
 
     docs = loader.load_data(branch="main")

--- a/llama_hub/github_repo/base.py
+++ b/llama_hub/github_repo/base.py
@@ -72,6 +72,7 @@ class GithubRepositoryReader(BaseReader):
         use_parser: bool = False,
         verbose: bool = False,
         concurrent_requests: int = 5,
+        timeout: Optional[int] = 5,
         filter_directories: Optional[Tuple[List[str], FilterType]] = None,
         filter_file_extensions: Optional[Tuple[List[str], FilterType]] = None,
     ):
@@ -87,6 +88,7 @@ class GithubRepositoryReader(BaseReader):
             - verbose (bool): Whether to print verbose messages.
             - concurrent_requests (int): Number of concurrent requests to
                 make to the Github API.
+            - timeout (int or None): Timeout for the requests to the Github API. Default is 5.
             - filter_directories (Optional[Tuple[List[str], FilterType]]): Tuple
                 containing a list of directories and a FilterType. If the FilterType
                 is INCLUDE, only the files in the directories in the list will be
@@ -109,6 +111,7 @@ class GithubRepositoryReader(BaseReader):
         self._use_parser = use_parser
         self._verbose = verbose
         self._concurrent_requests = concurrent_requests
+        self._timeout = timeout
         self._filter_directories = filter_directories
         self._filter_file_extensions = filter_file_extensions
 
@@ -224,7 +227,7 @@ class GithubRepositoryReader(BaseReader):
         :return: list of documents
         """
         commit_response: GitCommitResponseModel = self._loop.run_until_complete(
-            self._github_client.get_commit(self._owner, self._repo, commit_sha)
+            self._github_client.get_commit(self._owner, self._repo, commit_sha, timeout=self._timeout)
         )
 
         tree_sha = commit_response.commit.tree.sha
@@ -247,7 +250,7 @@ class GithubRepositoryReader(BaseReader):
         :return: list of documents
         """
         branch_data: GitBranchResponseModel = self._loop.run_until_complete(
-            self._github_client.get_branch(self._owner, self._repo, branch)
+            self._github_client.get_branch(self._owner, self._repo, branch, timeout=self._timeout)
         )
 
         tree_sha = branch_data.commit.commit.tree.sha
@@ -319,7 +322,7 @@ class GithubRepositoryReader(BaseReader):
         )
 
         tree_data: GitTreeResponseModel = await self._github_client.get_tree(
-            self._owner, self._repo, tree_sha
+            self._owner, self._repo, tree_sha, timeout=self._timeout
         )
         print_if_verbose(
             self._verbose, "\t" * current_depth + f"tree data: {tree_data}"

--- a/llama_hub/github_repo/base.py
+++ b/llama_hub/github_repo/base.py
@@ -227,7 +227,9 @@ class GithubRepositoryReader(BaseReader):
         :return: list of documents
         """
         commit_response: GitCommitResponseModel = self._loop.run_until_complete(
-            self._github_client.get_commit(self._owner, self._repo, commit_sha, timeout=self._timeout)
+            self._github_client.get_commit(
+                self._owner, self._repo, commit_sha, timeout=self._timeout
+            )
         )
 
         tree_sha = commit_response.commit.tree.sha
@@ -250,7 +252,9 @@ class GithubRepositoryReader(BaseReader):
         :return: list of documents
         """
         branch_data: GitBranchResponseModel = self._loop.run_until_complete(
-            self._github_client.get_branch(self._owner, self._repo, branch, timeout=self._timeout)
+            self._github_client.get_branch(
+                self._owner, self._repo, branch, timeout=self._timeout
+            )
         )
 
         tree_sha = branch_data.commit.commit.tree.sha

--- a/llama_hub/github_repo/github_client.py
+++ b/llama_hub/github_repo/github_client.py
@@ -271,6 +271,7 @@ class GithubClient:
         endpoint: str,
         method: str,
         headers: Dict[str, Any] = {},
+        timeout: Optional[int] = 5,
         **kwargs: Any,
     ) -> Any:
         """
@@ -283,6 +284,7 @@ class GithubClient:
             - `endpoint (str)`: Name of the endpoint to make the request to.
             - `method (str)`: HTTP method to use for the request.
             - `headers (dict)`: HTTP headers to include in the request.
+            - `timeout (int or None)`: Timeout for the request in seconds. Default is 5.
             - `**kwargs`: Keyword arguments to pass to the endpoint URL.
 
         Returns:
@@ -295,7 +297,7 @@ class GithubClient:
         Examples:
             >>> response = client.request("getTree", "GET",
                                 owner="owner", repo="repo",
-                                tree_sha="tree_sha")
+                                tree_sha="tree_sha", timeout=5)
         """
         try:
             import httpx
@@ -309,7 +311,9 @@ class GithubClient:
 
         _client: httpx.AsyncClient
         async with httpx.AsyncClient(
-            headers=_headers, base_url=self._base_url
+            headers=_headers, 
+            base_url=self._base_url,
+            timeout=timeout,
         ) as _client:
             try:
                 response = await _client.request(
@@ -326,6 +330,7 @@ class GithubClient:
         repo: str,
         branch: Optional[str] = None,
         branch_name: Optional[str] = None,
+        timeout: Optional[int] = 5,
     ) -> GitBranchResponseModel:
         """
         Get information about a branch. (Github API endpoint: getBranch).
@@ -349,13 +354,17 @@ class GithubClient:
         return GitBranchResponseModel.from_json(
             (
                 await self.request(
-                    "getBranch", "GET", owner=owner, repo=repo, branch=branch
+                    "getBranch", "GET", owner=owner, repo=repo, branch=branch, timeout=timeout
                 )
             ).text
         )
 
     async def get_tree(
-        self, owner: str, repo: str, tree_sha: str
+        self, 
+        owner: str, 
+        repo: str, 
+        tree_sha: str,
+        timeout: Optional[int] = 5,
     ) -> GitTreeResponseModel:
         """
         Get information about a tree. (Github API endpoint: getTree).
@@ -364,6 +373,7 @@ class GithubClient:
             - `owner (str)`: Owner of the repository.
             - `repo (str)`: Name of the repository.
             - `tree_sha (str)`: SHA of the tree.
+            - `timeout (int or None)`: Timeout for the request in seconds. Default is 5.
 
         Returns:
             - `tree_info (GitTreeResponseModel)`: Information about the tree.
@@ -374,13 +384,17 @@ class GithubClient:
         return GitTreeResponseModel.from_json(
             (
                 await self.request(
-                    "getTree", "GET", owner=owner, repo=repo, tree_sha=tree_sha
+                    "getTree", "GET", owner=owner, repo=repo, tree_sha=tree_sha, timeout=timeout
                 )
             ).text
         )
 
     async def get_blob(
-        self, owner: str, repo: str, file_sha: str
+        self, 
+        owner: str, 
+        repo: str, 
+        file_sha: str,
+        timeout: Optional[int] = 5,
     ) -> GitBlobResponseModel:
         """
         Get information about a blob. (Github API endpoint: getBlob).
@@ -389,6 +403,7 @@ class GithubClient:
             - `owner (str)`: Owner of the repository.
             - `repo (str)`: Name of the repository.
             - `file_sha (str)`: SHA of the file.
+            - `timeout (int or None)`: Timeout for the request in seconds. Default is 5.
 
         Returns:
             - `blob_info (GitBlobResponseModel)`: Information about the blob.
@@ -399,13 +414,17 @@ class GithubClient:
         return GitBlobResponseModel.from_json(
             (
                 await self.request(
-                    "getBlob", "GET", owner=owner, repo=repo, file_sha=file_sha
+                    "getBlob", "GET", owner=owner, repo=repo, file_sha=file_sha, timeout=timeout
                 )
             ).text
         )
 
     async def get_commit(
-        self, owner: str, repo: str, commit_sha: str
+        self, 
+        owner: str, 
+        repo: str, 
+        commit_sha: str,
+        timeout: Optional[int] = 5,
     ) -> GitCommitResponseModel:
         """
         Get information about a commit. (Github API endpoint: getCommit).
@@ -414,6 +433,7 @@ class GithubClient:
             - `owner (str)`: Owner of the repository.
             - `repo (str)`: Name of the repository.
             - `commit_sha (str)`: SHA of the commit.
+            - `timeout (int or None)`: Timeout for the request in seconds. Default is 5.
 
         Returns:
             - `commit_info (GitCommitResponseModel)`: Information about the commit.
@@ -424,7 +444,7 @@ class GithubClient:
         return GitCommitResponseModel.from_json(
             (
                 await self.request(
-                    "getCommit", "GET", owner=owner, repo=repo, commit_sha=commit_sha
+                    "getCommit", "GET", owner=owner, repo=repo, commit_sha=commit_sha, timeout=timeout
                 )
             ).text
         )

--- a/llama_hub/github_repo/github_client.py
+++ b/llama_hub/github_repo/github_client.py
@@ -311,7 +311,7 @@ class GithubClient:
 
         _client: httpx.AsyncClient
         async with httpx.AsyncClient(
-            headers=_headers, 
+            headers=_headers,
             base_url=self._base_url,
             timeout=timeout,
         ) as _client:
@@ -354,15 +354,20 @@ class GithubClient:
         return GitBranchResponseModel.from_json(
             (
                 await self.request(
-                    "getBranch", "GET", owner=owner, repo=repo, branch=branch, timeout=timeout
+                    "getBranch",
+                    "GET",
+                    owner=owner,
+                    repo=repo,
+                    branch=branch,
+                    timeout=timeout,
                 )
             ).text
         )
 
     async def get_tree(
-        self, 
-        owner: str, 
-        repo: str, 
+        self,
+        owner: str,
+        repo: str,
         tree_sha: str,
         timeout: Optional[int] = 5,
     ) -> GitTreeResponseModel:
@@ -384,15 +389,20 @@ class GithubClient:
         return GitTreeResponseModel.from_json(
             (
                 await self.request(
-                    "getTree", "GET", owner=owner, repo=repo, tree_sha=tree_sha, timeout=timeout
+                    "getTree",
+                    "GET",
+                    owner=owner,
+                    repo=repo,
+                    tree_sha=tree_sha,
+                    timeout=timeout,
                 )
             ).text
         )
 
     async def get_blob(
-        self, 
-        owner: str, 
-        repo: str, 
+        self,
+        owner: str,
+        repo: str,
         file_sha: str,
         timeout: Optional[int] = 5,
     ) -> GitBlobResponseModel:
@@ -414,15 +424,20 @@ class GithubClient:
         return GitBlobResponseModel.from_json(
             (
                 await self.request(
-                    "getBlob", "GET", owner=owner, repo=repo, file_sha=file_sha, timeout=timeout
+                    "getBlob",
+                    "GET",
+                    owner=owner,
+                    repo=repo,
+                    file_sha=file_sha,
+                    timeout=timeout,
                 )
             ).text
         )
 
     async def get_commit(
-        self, 
-        owner: str, 
-        repo: str, 
+        self,
+        owner: str,
+        repo: str,
         commit_sha: str,
         timeout: Optional[int] = 5,
     ) -> GitCommitResponseModel:
@@ -444,7 +459,12 @@ class GithubClient:
         return GitCommitResponseModel.from_json(
             (
                 await self.request(
-                    "getCommit", "GET", owner=owner, repo=repo, commit_sha=commit_sha, timeout=timeout
+                    "getCommit",
+                    "GET",
+                    owner=owner,
+                    repo=repo,
+                    commit_sha=commit_sha,
+                    timeout=timeout,
                 )
             ).text
         )


### PR DESCRIPTION
# Description

This PR adds a `timeout` arg to the GithubRepositoryReader to allow users to specify a timeout when making requests.
Fixes #846 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix / Smaller change

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods