### PR TITLE
Fix docs: query index

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ gdoc_ids = ['1wf-y2pd9C878Oh-FmLH7Q_BQkljdm6TQal-c1pUfrec']
 loader = GoogleDocsReader()
 documents = loader.load_data(document_ids=gdoc_ids)
 index = VectorStoreIndex.from_documents(documents)
-index.query('Where did the author go to school?')
+query_engine = index.as_query_engine()
+query_engine.query('Where did the author go to school?')
 ```
 
 ### LlamaIndex Data Agent
@@ -93,7 +94,8 @@ gdoc_ids = ['1wf-y2pd9C878Oh-FmLH7Q_BQkljdm6TQal-c1pUfrec']
 loader = GoogleDocsReader()
 documents = loader.load_data(document_ids=gdoc_ids)
 index = VectorStoreIndex.from_documents(documents)
-index.query('Where did the author go to school?')
+query_engine = index.as_query_engine()
+query_engine.query('Where did the author go to school?')
 
 ```
 
@@ -145,7 +147,7 @@ rag_dataset, documents = download_llama_dataset(
 
 # build basic RAG system
 index = VectorStoreIndex.from_documents(documents=documents)
-query_engine = VectorStoreIndex.as_query_engine()
+query_engine = index.as_query_engine()
 
 # evaluate using the RagEvaluatorPack
 RagEvaluatorPack = download_llama_pack(

--- a/llama_hub/azcognitive_search/README.md
+++ b/llama_hub/azcognitive_search/README.md
@@ -43,11 +43,12 @@ documents = reader.load_data(
     documents = az_loader.load_data(query, field_name)
 
     index = VectorStoreIndex.from_documents(documents, service_context=service_context)
+    query_engine = index.as_query_engine()
 
     tools = [
         Tool(
             name="Azure cognitive search index",
-            func=lambda q: index.query(q),
+            func=lambda q: query_engine.query(q),
             description=f"Useful when you want answer questions about the text on azure cognitive search.",
         ),
     ]

--- a/llama_hub/boarddocs/BoardDocsReader.ipynb
+++ b/llama_hub/boarddocs/BoardDocsReader.ipynb
@@ -92,7 +92,8 @@
    ],
    "source": [
     "# Now we can start asking it questions!!\n",
-    "answer = index.query(\"When did Trustee Weekly start attending meetings?\")\n",
+    "query_engine = index.as_query_engine()\n",
+    "answer = query_engine.query(\"When did Trustee Weekly start attending meetings?\")\n",
     "print(answer.response)"
    ]
   }

--- a/llama_hub/file/README.md
+++ b/llama_hub/file/README.md
@@ -34,7 +34,8 @@ from llama_index import VectorStoreIndex
 loader = SimpleDirectoryReader('./data', recursive=True, exclude_hidden=True)
 documents = loader.load_data()
 index = VectorStoreIndex.from_documents(documents)
-index.query('What are these files about?')
+query_engine = index.as_query_engine()
+query_engine.query('What are these files about?')
 ```
 
 ### LangChain
@@ -55,11 +56,12 @@ from langchain.chains.conversation.memory import ConversationBufferMemory
 loader = SimpleDirectoryReader('./data', recursive=True, exclude_hidden=True)
 documents = loader.load_data()
 index = VectorStoreIndex.from_documents(documents)
+query_engine = index.as_query_engine()
 
 tools = [
     Tool(
         name="Local Directory Index",
-        func=lambda q: index.query(q),
+        func=lambda q: query_engine.query(q),
         description=f"Useful when you want answer questions about the files in your local directory.",
     ),
 ]

--- a/llama_hub/google_calendar/README.md
+++ b/llama_hub/google_calendar/README.md
@@ -31,5 +31,6 @@ GoogleCalendarReader = download_loader('GoogleCalendarReader')
 loader = GoogleCalendarReader()
 documents = loader.load_data()
 index = VectorStoreIndex.from_documents(documents)
-index.query('When am I meeting Gordon?')
+query_engine = index.as_query_engine()
+query_engine.query('When am I meeting Gordon?')
 ```

--- a/llama_hub/google_docs/README.md
+++ b/llama_hub/google_docs/README.md
@@ -33,7 +33,8 @@ gdoc_ids = ['1wf-y2pd9C878Oh-FmLH7Q_BQkljdm6TQal-c1pUfrec']
 loader = GoogleDocsReader()
 documents = loader.load_data(document_ids=gdoc_ids)
 index = VectorStoreIndex.from_documents(documents)
-index.query('Where did the author go to school?')
+query_engine = index.as_query_engine()
+query_engine.query('Where did the author go to school?')
 ```
 
 ### LangChain
@@ -52,11 +53,12 @@ gdoc_ids = ['1wf-y2pd9C878Oh-FmLH7Q_BQkljdm6TQal-c1pUfrec']
 loader = GoogleDocsReader()
 documents = loader.load_data(document_ids=gdoc_ids)
 index = VectorStoreIndex.from_documents(documents)
+query_engine = index.as_query_engine()
 
 tools = [
     Tool(
         name="Google Doc Index",
-        func=lambda q: index.query(q),
+        func=lambda q: query_engine.query(q),
         description=f"Useful when you want answer questions about the Google Documents.",
     ),
 ]

--- a/llama_hub/google_sheets/README.md
+++ b/llama_hub/google_sheets/README.md
@@ -31,5 +31,6 @@ GoogleSheetsReader = download_loader('GoogleSheetsReader')
 loader = GoogleSheetsReader()
 documents = loader.load_data()
 index = VectorStoreIndex.from_documents(documents)
-index.query('When am I meeting Gordon?')
+query_engine = index.as_query_engine()
+query_engine.query('When am I meeting Gordon?')
 ```

--- a/llama_hub/jsondata/README.md
+++ b/llama_hub/jsondata/README.md
@@ -18,6 +18,7 @@ JsonDataReader = download_loader("JsonDataReader")
 loader = JsonDataReader()
 documents = loader.load_data(data)
 index = VectorStoreIndex.from_documents(documents)
-index.query("Question about your data")
+query_engine = index.as_query_engine()
+query_engine.query("Question about your data")
 ```
 

--- a/llama_hub/lilac_reader/README.md
+++ b/llama_hub/lilac_reader/README.md
@@ -59,8 +59,8 @@ documents = loader.load_data(
     dataset='local/arxiv-karpathy')
 
 index = VectorStoreIndex.from_documents(documents)
-
-index.query("How are ImageNet labels validated?")
+query_engine = index.as_query_engine()
+query_engine.query("How are ImageNet labels validated?")
 ```
 
 This loader is designed to be used as a way to load data into [GPT Index](https://github.com/run-llama/llama_index/tree/main/llama_index) and/or subsequently used in a [LangChain](https://github.com/hwchase17/langchain) Agent.

--- a/llama_hub/make_com/README.md
+++ b/llama_hub/make_com/README.md
@@ -19,7 +19,8 @@ index = VectorStoreIndex.load_from_disk('../vector_indices/index_simple.json')
 
 # query index
 query_str = "What did the author do growing up?"
-response = index.query(query_str)
+query_engine = index.as_query_engine()
+response = query_engine.query(query_str)
 
 # Send response to Make.com webhook
 wrapper = MakeWrapper()

--- a/llama_hub/outlook_localcalendar/README.md
+++ b/llama_hub/outlook_localcalendar/README.md
@@ -34,6 +34,7 @@ loader = OutlookCalendarReader(start_date='2022-01-01',number_of_documents=1000)
 
 documents = loader.load_data()
 index = VectorStoreIndex.from_documents(documents)
-index.query('When did I last see George Guava? When do I see him again?')
+query_engine = index.as_query_engine()
+query_engine.query('When did I last see George Guava? When do I see him again?')
 ```
 Note: it is actually better to give s structured prompt with this data and be sure to it is clear what today's date is and whether you want any data besides the indexed data used in answering the prompt.

--- a/llama_hub/readwise/README.md
+++ b/llama_hub/readwise/README.md
@@ -19,8 +19,8 @@ token = os.getenv("READWISE_API_KEY")
 loader = ReadwiseReader(api_key=token)
 documents = loader.load_data()
 index = VectorStoreIndex.from_documents(documents)
-
-index.query("What was the paper 'Attention is all you need' about?")
+query_engine = index.as_query_engine()
+query_engine.query("What was the paper 'Attention is all you need' about?")
 ```
 
 You can also query for highlights that have been created after a certain time:
@@ -36,8 +36,9 @@ loader = ReadwiseReader(api_key=token)
 seven_days_ago = datetime.datetime.now() - datetime.timedelta(days=7)
 documents = loader.load_data(updated_after=seven_days_ago)
 index = VectorStoreIndex.from_documents(documents)
+query_engine = index.as_query_engine()
 
-index.query("What has Elon Musk done this time?")
+query_engine.query("What has Elon Musk done this time?")
 ```
 
 This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/run-llama/llama_index/tree/main/llama_index) and/or subsequently used as a Tool in a [LangChain](https://github.com/hwchase17/langchain) Agent. See [here](https://github.com/emptycrown/llama-hub/tree/main) for examples.

--- a/llama_hub/reddit/README.md
+++ b/llama_hub/reddit/README.md
@@ -26,8 +26,9 @@ post_limit = 10
 loader = RedditReader()
 documents = loader.load_data(subreddits=subreddits, search_keys=search_keys, post_limit=post_limit)
 index = VectorStoreIndex.from_documents(documents)
+query_engine = index.as_query_engine()
 
-index.query("What are the pain points of PyTorch users?")
+query_engine.query("What are the pain points of PyTorch users?")
 ```
 
 ### LangChain
@@ -48,11 +49,12 @@ post_limit = 10
 loader = RedditReader()
 documents = loader.load_data(subreddits=subreddits, search_keys=search_keys, post_limit=post_limit)
 index = VectorStoreIndex.from_documents(documents)
+query_engine = index.as_query_engine()
 
 tools = [
     Tool(
         name="Reddit Index",
-        func=lambda q: index.query(q),
+        func=lambda q: query_engine.query(q),
         description=f"Useful when you want to read relevant posts and top-level comments in subreddits.",
     ),
 ]

--- a/llama_hub/sec_filings/README.md
+++ b/llama_hub/sec_filings/README.md
@@ -102,7 +102,9 @@ loader.load_data()
 
 documents = SimpleDirectoryReader("data\TSLA\2022").load_data()
 index = VectorStoreIndex.from_documents(documents)
-index.query('What are the risk factors of Tesla for the year 2022?')
+query_engine = index.as_query_engine()
+
+query_enginee.query('What are the risk factors of Tesla for the year 2022?')
 
 ```
 

--- a/llama_hub/spotify/README.md
+++ b/llama_hub/spotify/README.md
@@ -36,5 +36,7 @@ SpotifyReader = download_loader('SpotifyReader')
 loader = SpotifyReader()
 documents = loader.load_data()
 index = VectorStoreIndex.from_documents(documents)
-index.query('When are some other artists i might like based on what i listen to ?')
+query_engine = index.as_query_engine()
+
+query_engine.query('When are some other artists i might like based on what i listen to ?')
 ```

--- a/llama_hub/string_iterable/base.py
+++ b/llama_hub/string_iterable/base.py
@@ -18,7 +18,8 @@ class StringIterableReader(BaseReader):
             documents = StringIterableReader().load_data(
                 texts=["I went to the store", "I bought an apple"])
             index = GPTTreeIndex(documents)
-            index.query("what did I buy?")
+            query_engine = index.as_query_engine()
+            query_engine.query("what did I buy?")
 
             # response should be something like "You bought an apple."
     """

--- a/llama_hub/web/beautiful_soup_web/README.md
+++ b/llama_hub/web/beautiful_soup_web/README.md
@@ -43,7 +43,8 @@ BeautifulSoupWebReader = download_loader("BeautifulSoupWebReader")
 loader = BeautifulSoupWebReader()
 documents = loader.load_data(urls=['https://google.com'])
 index = VectorStoreIndex.from_documents(documents)
-index.query('What language is on this website?')
+query_engine = index.as_query_engine()
+query_engine.query('What language is on this website?')
 ```
 
 ### LangChain
@@ -61,11 +62,12 @@ BeautifulSoupWebReader = download_loader("BeautifulSoupWebReader")
 loader = BeautifulSoupWebReader()
 documents = loader.load_data(urls=['https://google.com'])
 index = VectorStoreIndex.from_documents(documents)
+query_engine = index.as_query_engine()
 
 tools = [
     Tool(
         name="Website Index",
-        func=lambda q: index.query(q),
+        func=lambda q: query_engine.query(q),
         description=f"Useful when you want answer questions about the text on websites.",
     ),
 ]

--- a/llama_hub/web/knowledge_base/README.md
+++ b/llama_hub/web/knowledge_base/README.md
@@ -51,7 +51,8 @@ documents = loader.load_data(
   subtitle_selector='.article-subtitle'
   )
 index = VectorStoreIndex.from_documents(documents)
-index.query('What languages does Intercom support?')
+query_engine = index.as_query_engine()
+query_engine.query('What languages does Intercom support?')
 ```
 
 ### LangChain
@@ -76,11 +77,12 @@ documents = loader.load_data(
   subtitle_selector='.article-subtitle'
   )
 index = VectorStoreIndex.from_documents(documents)
+query_engine = index.as_query_engine()
 
 tools = [
     Tool(
         name="Website Index",
-        func=lambda q: index.query(q),
+        func=lambda q: query_engine.query(q),
         description=f"Useful when you want answer questions about a product that has a public knowledge base.",
     ),
 ]

--- a/llama_hub/web/main_content_extractor/README.md
+++ b/llama_hub/web/main_content_extractor/README.md
@@ -31,7 +31,8 @@ MainContentExtractorReader = download_loader("MainContentExtractorReader")
 loader = MainContentExtractorReader()
 documents = loader.load_data(urls=['https://google.com'])
 index = VectorStoreIndex.from_documents(documents)
-index.query('What language is on this website?')
+query_engine = index.as_query_engine()
+query_engine.query('What language is on this website?')
 ```
 
 ### LangChain
@@ -49,11 +50,12 @@ MainContentExtractorReader = download_loader("MainContentExtractorReader")
 loader = MainContentExtractorReader()
 documents = loader.load_data(urls=['https://google.com'])
 index = VectorStoreIndex.from_documents(documents)
+query_engine = index.as_query_engine()
 
 tools = [
     Tool(
         name="Website Index",
-        func=lambda q: index.query(q),
+        func=lambda q: query_engine.query(q),
         description=f"Useful when you want answer questions about the text on websites.",
     ),
 ]

--- a/llama_hub/web/readability_web/README.md
+++ b/llama_hub/web/readability_web/README.md
@@ -39,7 +39,9 @@ loader = ReadabilityWebPageReader()
 documents = loader.load_data(url='https://support.squarespace.com/hc/en-us/articles/206795137-Pages-and-content-basics')
 
 index = VectorStoreIndex.from_documents(documents)
-print(index.query('What is pages?'))
+query_engine = index.as_query_engine()
+
+print(query_engine.query('What is pages?'))
 
 ```
 
@@ -59,11 +61,12 @@ loader = ReadabilityWebPageReader()
 documents = loader.load_data(url='https://support.squarespace.com/hc/en-us/articles/206795137-Pages-and-content-basics')
 
 index = VectorStoreIndex.from_documents(documents)
+query_engine = index.as_query_engine()
 
 tools = [
     Tool(
         name="Website Index",
-        func=lambda q: index.query(q),
+        func=lambda q: query_engine.query(q),
         description=f"Useful when you want answer questions about the text on websites.",
     ),
 ]

--- a/llama_hub/web/simple_web/README.md
+++ b/llama_hub/web/simple_web/README.md
@@ -29,7 +29,9 @@ SimpleWebPageReader = download_loader("SimpleWebPageReader")
 loader = SimpleWebPageReader()
 documents = loader.load_data(urls=['https://google.com'])
 index = VectorStoreIndex.from_documents(documents)
-index.query('What language is on this website?')
+query_engine = index.as_query_engine()
+
+query_engine.query('What language is on this website?')
 ```
 
 ### LangChain
@@ -47,11 +49,12 @@ SimpleWebPageReader = download_loader("SimpleWebPageReader")
 loader = SimpleWebPageReader()
 documents = loader.load_data(urls=['https://google.com'])
 index = VectorStoreIndex.from_documents(documents)
+query_engine = index.as_query_engine()
 
 tools = [
     Tool(
         name="Website Index",
-        func=lambda q: index.query(q),
+        func=lambda q: query_engine.query(q),
         description=f"Useful when you want answer questions about the text on websites.",
     ),
 ]

--- a/llama_hub/web/trafilatura_web/README.md
+++ b/llama_hub/web/trafilatura_web/README.md
@@ -29,7 +29,9 @@ TrafilaturaWebReader = download_loader("TrafilaturaWebReader")
 loader = TrafilaturaWebReader()
 documents = loader.load_data(urls=['https://google.com'])
 index = VectorStoreIndex.from_documents(documents)
-index.query('What language is on this website?')
+query_engine = index.as_query_engine()
+
+query_engine.query('What language is on this website?')
 ```
 
 ### LangChain
@@ -47,11 +49,12 @@ TrafilaturaWebReader = download_loader("TrafilaturaWebReader")
 loader = TrafilaturaWebReader()
 documents = loader.load_data(urls=['https://google.com'])
 index = VectorStoreIndex.from_documents(documents)
+query_engine = index.as_query_engine()
 
 tools = [
     Tool(
         name="Website Index",
-        func=lambda q: index.query(q),
+        func=lambda q: query_engine.query(q),
         description=f"Useful when you want answer questions about the text on websites.",
     ),
 ]

--- a/llama_hub/web/whole_site/README.md
+++ b/llama_hub/web/whole_site/README.md
@@ -43,7 +43,9 @@ scraper = WholeSiteReader(
 # Start scraping from a base URL
 documents = scraper.load_data(base_url='https://docs.llamaindex.ai/en/stable/') # Example base URL
 index = VectorStoreIndex.from_documents(documents)
-index.query('What language is on this website?')
+query_engine = index.as_query_engine()
+
+query_engine.query('What language is on this website?')
 ```
 
 ### LangChain
@@ -67,11 +69,12 @@ scraper = WholeSiteReader(
 # Start scraping from a base URL
 documents = scraper.load_data(base_url='https://docs.llamaindex.ai/en/stable/') # Example base URL
 index = VectorStoreIndex.from_documents(documents)
+query_engine = index.as_query_engine()
 
 tools = [
     Tool(
         name="Website Index",
-        func=lambda q: index.query(q),
+        func=lambda q: query_engine.query(q),
         description=f"Useful when you want answer questions about the text on websites.",
     ),
 ]


### PR DESCRIPTION
# Description

In this PR, there's a fix for documentation about querying indices:
```
index = VectorStoreIndex.from_documents(documents)
index.query(question)
```
which should be:
```
index = VectorStoreIndex.from_documents(documents)
query_engine = index.as_query_engine()
query_engine.query(question)
```

Fixes #874

## Type of Change

Please delete options that are not relevant.

- [ ] New Loader/Tool
- [x] Bug fix / Smaller change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have added a library.json file if a new loader/tool was added
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods