### PR TITLE
fix(PyMuPDF): store the str path instead of the Path object

### DIFF
--- a/llama_hub/file/pymu_pdf/base.py
+++ b/llama_hub/file/pymu_pdf/base.py
@@ -1,4 +1,5 @@
 """Read PDF files using PyMuPDF library."""
+
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
@@ -57,7 +58,7 @@ class PyMuPDFReader(BaseReader):
             if not extra_info:
                 extra_info = {}
             extra_info["total_pages"] = len(doc)
-            extra_info["file_path"] = file_path
+            extra_info["file_path"] = str(file_path)
 
             # return list of documents
             return [


### PR DESCRIPTION
# Description

Store the path in str when using the PyMuPDF Loader in case a Path object is passed.

## Type of Change

- [x] Bug fix / Smaller change

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have added a library.json file if a new loader/tool was added
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods