### PR TITLE
Fix to confluence loader documentation.

### DIFF
--- a/llama_hub/confluence/README.md
+++ b/llama_hub/confluence/README.md
@@ -3,7 +3,7 @@
 This loader loads pages from a given Confluence cloud instance. The user needs to specify the base URL for a Confluence 
 instance to initialize the ConfluenceReader - base URL needs to end with `/wiki`. The user can optionally specify 
 OAuth 2.0 credentials to authenticate with the Confluence instance. If no credentials are specified, the loader will
-look for `CONFLUENCE_API_TOKEN` or `CONFLUENCE_USERNAME`/`CONFLUENCE_PASSWORD` environment variables to proceed with basic authentication.
+look for `CONFLUENCE_API_TOKEN` or `CONFLUENCE_USERNAME`/`CONFLUENCE_PASSWORD` environment variables to proceed with basic authentication. Keep in mind `CONFLUENCE_PASSWORD` is not your actual password, but an API Token obtained here: https://id.atlassian.com/manage-profile/security/api-tokens.
 
 For more on authenticating using OAuth 2.0, checkout:
 - https://atlassian-python-api.readthedocs.io/index.html


### PR DESCRIPTION
Add clarity on how to use basic auth.

# Description

Change to documentation for Confluence loader, which provide clarity on how to use basic auth. 
There is at least one open bug request where people are confused how to use this loader with login/password .

Fixes #795

## Type of Change

- [x] Documentation update

# How Has This Been Tested?

This update is strictly for README file and doesn't require testing
