### PR TITLE
Fuzzy citation bugfix

### DIFF
--- a/llama_hub/llama_packs/fuzzy_citation/base.py
+++ b/llama_hub/llama_packs/fuzzy_citation/base.py
@@ -59,12 +59,13 @@ class FuzzyCitationQueryEngine(CustomQueryEngine):
             # concat nearby sentences
             top_chunks = defaultdict(list)
             prev_idx = -1
+            prev_response_sent_idx = -1
             for response_sent_idx, node_sent_idx in sorted(top_sentences.keys()):
                 if prev_idx == -1:
                     top_chunks[response_sent_idx].append(
                         top_sentences[(response_sent_idx, node_sent_idx)]
                     )
-                elif node_sent_idx - prev_idx == 1:
+                elif prev_response_sent_idx == response_sent_idx and node_sent_idx - prev_idx == 1:
                     top_chunks[response_sent_idx][-1] += top_sentences[
                         (response_sent_idx, node_sent_idx)
                     ]
@@ -73,6 +74,7 @@ class FuzzyCitationQueryEngine(CustomQueryEngine):
                         top_sentences[(response_sent_idx, node_sent_idx)]
                     )
                 prev_idx = node_sent_idx
+                prev_response_sent_idx = response_sent_idx
 
             # associate chunks with their nodes
             for response_sent_idx, chunks in top_chunks.items():


### PR DESCRIPTION
# Description

This PR fixes out of range error in `fuzzy_citation` pack that happens in case there are more than one response sentences.

```
Exception has occurred: IndexError
list index out of range

  File ".../python3.11/site-packages/llama_hub/llama_packs/fuzzy_citation/base.py", line 68, in get_relevant_sentences
    top_chunks[response_sent_idx][-1] += top_sentences[
        ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^

```
## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix / Smaller change

# How Has This Been Tested?

Tested with demo fuzzy_citation notebook.

- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings