### PR TITLE
asyncio bug fix in telegram loader

### DIFF
--- a/llama_hub/telegram/base.py
+++ b/llama_hub/telegram/base.py
@@ -47,7 +47,8 @@ class TelegramReader(BaseReader):
         self.api_id = api_id
         self.api_hash = api_hash
         self.phone_number = phone_number
-        self.loop = asyncio.get_event_loop()
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
 
     def load_data(
         self,


### PR DESCRIPTION
# Description

I encountered this error while using the Telegram Loader in a FastAPI application: "RuntimeError: There is no current event loop in thread 'AnyIO worker thread'." I resolved it by replacing `asyncio.get_event_loop()` with `asyncio.new_event_loop()`.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] New Loader/Tool
- [x] Bug fix / Smaller change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have added a library.json file if a new loader/tool was added
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods