### PR TITLE
Remove links from telegram text messages

### DIFF
--- a/llama_hub/telegram/base.py
+++ b/llama_hub/telegram/base.py
@@ -1,5 +1,6 @@
 """Telegram reader that reads posts/chats and comments to post from Telegram channel or chat."""
 import asyncio
+import re
 from typing import List, Union
 
 from llama_index.readers.base import BaseReader
@@ -102,5 +103,15 @@ class TelegramReader(BaseReader):
                 entity_name, reply_to=post_id, limit=limit
             ):
                 if isinstance(message.text, str) and message.text != "":
-                    results.append(Document(text=message.text))
+                    results.append(Document(text=self._remove_links(message.text)))
         return results
+
+    def _remove_links(self, string) -> str:
+        """Removes all URLs from a given string, leaving only the base domain name."""
+
+        def replace_match(match):
+            text = match.group(1)
+            return text if text else ""
+
+        url_pattern = r"https?://(?:www\.)?((?!www\.).)+?"
+        return re.sub(url_pattern, replace_match, string)


### PR DESCRIPTION
# Description

I encountered an issue while loading data from Telegram posts/messages: if there were many links, it wouldn't pass the OpenAI moderation, resulting in the response: "Sorry, I can't answer, there are too many links." Hence, I utilized regular expressions (re) to remove the links, retaining only the domain (as it could be useful) before converting the text into a Document object.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] New Loader/Tool
- [x] Bug fix / Smaller change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have added a library.json file if a new loader/tool was added
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods